### PR TITLE
fix get_edges_between_timestamps() bug

### DIFF
--- a/dgnn/dynamic_graph.py
+++ b/dgnn/dynamic_graph.py
@@ -381,6 +381,15 @@ class DynamicGraph:
 
                     break
                 else:
-                    assert False, "should not reach here"
+                    # the whole block is in the range
+                    target_vertices = torch.cat(
+                        (target_vertices, curr_block.target_vertices.flip(dims=[0]).cpu()), dim=0)
+                    timestamps = torch.cat(
+                        (timestamps, curr_block.timestamps.flip(dims=[0]).cpu()), dim=0)
+                    edge_ids = torch.cat(
+                        (edge_ids, curr_block.edge_ids.flip(dims=[0]).cpu()), dim=0)
+
+                    curr_block = curr_block.next_block
+                    continue
 
         return target_vertices, timestamps, edge_ids

--- a/tests/test_dynamic_graph.py
+++ b/tests/test_dynamic_graph.py
@@ -289,7 +289,7 @@ class TestDynamicGraph(unittest.TestCase):
         self.assertEqual(target_vertices.tolist(), [3, 2, 1])
         self.assertEqual(timestamps.tolist(), [2, 1, 0])
         self.assertEqual(edge_ids.tolist(), [2, 1, 0])
-        print("Test out edges before timestamp with a larger timestamp passed.")
+        print("Test add edges before timestamp with a larger timestamp passed.")
 
     def test_get_neighbors_before_timestamp_with_a_smaller_timestamp(self):
         """
@@ -307,7 +307,7 @@ class TestDynamicGraph(unittest.TestCase):
         self.assertEqual(target_vertices.tolist(), [])
         self.assertEqual(timestamps.tolist(), [])
         self.assertEqual(edge_ids.tolist(), [])
-        print("Test out edges before timestamp with a smaller timestamp passed.")
+        print("Test add edges before timestamp with a smaller timestamp passed.")
 
     def test_get_neighbors_after_timestamp(self):
         """
@@ -324,7 +324,7 @@ class TestDynamicGraph(unittest.TestCase):
         self.assertEqual(target_vertices.tolist(), [3])
         self.assertEqual(timestamps.tolist(), [2])
         self.assertEqual(edge_ids.tolist(), [2])
-        print("Test in edges after timestamp passed.")
+        print("Test add edges after timestamp passed.")
 
     def test_get_neighbors_between_timestamps(self):
         """
@@ -357,4 +357,24 @@ class TestDynamicGraph(unittest.TestCase):
         self.assertEqual(timestamps.tolist(), [4, 3])
         self.assertEqual(edge_ids.tolist(), [4, 3])
 
-        print("Test out edges between timestamps passed.")
+        print("Test add edges between timestamps passed.")
+
+    def test_get_neighbors_between_timestamps_out_of_range(self):
+        """
+        Test if get_neighbors_between_timestamps works when the timestamps are
+        out of range.
+        """
+        dgraph = DynamicGraph(block_size=1)
+        source_vertices = torch.tensor([0, 0, 0, 1, 1, 1, 2, 2, 2])
+        target_vertices = torch.tensor([1, 2, 3, 1, 2, 3, 1, 2, 3])
+        timestamps = torch.tensor([0, 1, 2, 0, 1, 2, 0, 1, 2])
+        dgraph.add_edges(source_vertices, target_vertices, timestamps)
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            0, 1.5, 3.5)
+        self.assertEqual(target_vertices.tolist(), [3])
+        self.assertEqual(timestamps.tolist(), [2])
+        self.assertEqual(edge_ids.tolist(), [2])
+
+        print("Test add edges between timestamps out of range passed.")
+


### PR DESCRIPTION
- [x] fix `get_edges_between_timestamps()` when the `end_timestamp` > current block's end_timestamp and `start_timestamp` < current block's start_timestamp. In this case, all edges in the block should return. 