### PR TITLE
fix doubly linked list copy bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,5 @@ _deps
 .vscode
 data/
 .clangd/
+
+rmm_log.txt

--- a/dgnn/src/doubly_linked_list.h
+++ b/dgnn/src/doubly_linked_list.h
@@ -13,16 +13,10 @@ namespace dgnn {
  * @brief This class is doubly linked list of temporal blocks.
  */
 struct DoublyLinkedList {
-  TemporalBlock head;
-  TemporalBlock tail;
-  std::size_t size;
+  TemporalBlock* head;
+  TemporalBlock* tail;
 
-  __host__ __device__ DoublyLinkedList() : size(0) {
-    head.prev = nullptr;
-    head.next = &tail;
-    tail.prev = &head;
-    tail.next = nullptr;
-  }
+  __host__ __device__ DoublyLinkedList() : head(nullptr), tail(nullptr) {}
 };
 
 __host__ __device__ void InsertBlockToDoublyLinkedList(

--- a/tests/test_dynamic_graph.py
+++ b/tests/test_dynamic_graph.py
@@ -385,7 +385,7 @@ class TestDynamicGraph(unittest.TestCase):
         self.assertEqual(dgraph.out_degree(3), 0)
 
         target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(0)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+        self.assertEqual(target_vertices.tolist(), [4, 3, 2, 1, 3, 2, 1])
         self.assertEqual(timestamps.tolist(), [6, 5, 4, 3, 2, 1, 0])
         self.assertEqual(edge_ids.tolist(), [18, 11, 10, 9, 2, 1, 0])
 


### PR DESCRIPTION
Previous:
```cpp
struct DoublyLinkedList {
  TemporalBlock head;
  TemporalBlock tail;
  std::size_t size;

  __host__ __device__ DoublyLinkedList() : size(0) {
    head.prev = nullptr;
    head.next = &tail;
    tail.prev = &head;
    tail.next = nullptr;
  }
};
```

Now:
```cpp
struct DoublyLinkedList {
  TemporalBlock* head;
  TemporalBlock* tail;

  __host__ __device__ DoublyLinkedList() : head(nullptr), tail(nullptr) {}
};
```

Reason: std::vector.resize() would copy original data and thus make the pointers in `DoublyLinkedList` wrong. 