### PR TITLE
feat: support dynamic batch size for sampler

### DIFF
--- a/dgnn/csrc/temporal_sampler.h
+++ b/dgnn/csrc/temporal_sampler.h
@@ -32,6 +32,8 @@ class TemporalSampler {
 
   void InitBuffer(std::size_t num_root_nodes);
 
+  void FreeBuffer();
+
  private:
   const DynamicGraph& graph_;
   std::vector<uint32_t> fanouts_;
@@ -48,7 +50,7 @@ class TemporalSampler {
   char** gpu_input_buffer_;
   char** gpu_output_buffer_;
   curandState_t** rand_states_;
-  bool initialized_;
+  std::size_t init_num_root_nodes_;
 };
 
 }  // namespace dgnn

--- a/tests/test_temporal_sampler.py
+++ b/tests/test_temporal_sampler.py
@@ -332,3 +332,22 @@ class TestTemporalSampler(unittest.TestCase):
         self.assertEqual(block.edges()[1].tolist(), [0, 0, 1, 1, 2, 2])
 
         print("Test sample_multi_layers_multi_snapshots passed")
+
+    def test_sample_layer_with_different_batch_size(self):
+        # build the dynamic graph
+        dgraph = DynamicGraph()
+        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
+        dgraph.add_edges(source_vertices, target_vertices,
+                         timestamps, add_reverse=False)
+
+        # sample 1-hop neighbors
+        sampler = TemporalSampler(dgraph, [2])
+        for bs in range(0, 100, 10):
+            target_vertices = np.random.randint(0, 3, bs)
+            timestamps = np.random.randint(0, 3, bs)
+            sampler.sample(target_vertices,
+                           timestamps)
+
+        print("Test sample_layer_with_different_batch_size passed")


### PR DESCRIPTION
The batch size may change during the training. The sampler will keep the maximum batch size it has seen and reallocate the buffer accordingly.  