### PR TITLE
feat: swap the oldest block using sequence number

### DIFF
--- a/dgnn/csrc/dynamic_graph.h
+++ b/dgnn/csrc/dynamic_graph.h
@@ -75,6 +75,7 @@ class DynamicGraph {
                           const std::vector<TimestampType>& timestamps,
                           const std::vector<EIDType>& eids);
 
+  // Policy: swap the oldest block to the host.
   std::size_t SwapOldBlocksToCPU(std::size_t min_swap_size);
 
   TemporalBlock* AllocateBlock(std::size_t num_edges);
@@ -112,6 +113,9 @@ class DynamicGraph {
 
   std::size_t num_nodes_;  // the maximum node id + 1
   std::size_t num_edges_;
+
+  // block in the CPU memory but points to the GPU buffers -> src node
+  std::unordered_map<TemporalBlock*, NIDType> block_to_node_id_;
 };
 
 }  // namespace dgnn

--- a/dgnn/csrc/temporal_block_allocator.cu
+++ b/dgnn/csrc/temporal_block_allocator.cu
@@ -10,7 +10,7 @@ namespace dgnn {
 
 TemporalBlockAllocator::TemporalBlockAllocator(
     std::size_t max_gpu_mem_pool_size, std::size_t min_block_size)
-    : min_block_size_(min_block_size), block_id_counter_(0) {
+    : min_block_size_(min_block_size), block_sequence_number_(0) {
   // create a memory pool
   auto mem_res = new rmm::mr::cuda_memory_resource();
   gpu_resources_.push(mem_res);
@@ -51,7 +51,7 @@ TemporalBlockAllocator::~TemporalBlockAllocator() {
 
   blocks_on_device_.clear();
   blocks_on_host_.clear();
-  block_to_id_.clear();
+  block_to_seq_.clear();
 }
 
 std::size_t TemporalBlockAllocator::AlignUp(std::size_t size) {
@@ -79,9 +79,9 @@ TemporalBlock *TemporalBlockAllocator::Allocate(std::size_t size) noexcept(
 
   {
     std::lock_guard<std::mutex> lock(mutex_);
-    blocks_on_device_[block_id_counter_] = block;
-    block_to_id_[block] = block_id_counter_;
-    block_id_counter_++;
+    blocks_on_device_[block_sequence_number_] = block;
+    block_to_seq_[block] = block_sequence_number_;
+    block_sequence_number_++;
   }
   return block;
 }
@@ -92,8 +92,8 @@ void TemporalBlockAllocator::Deallocate(TemporalBlock *block) {
 
   {
     std::lock_guard<std::mutex> lock(mutex_);
-    blocks_on_device_.erase(block_to_id_[block]);
-    block_to_id_.erase(block);
+    blocks_on_device_.erase(block_to_seq_[block]);
+    block_to_seq_.erase(block);
   }
 }
 
@@ -133,23 +133,23 @@ void TemporalBlockAllocator::DeallocateInternal(TemporalBlock *block) {
   }
 }
 
+TemporalBlock *TemporalBlockAllocator::GetTheOldestBlockOnDevice() const {
+  auto the_oldest_block_on_device = blocks_on_device_.begin()->second;
+  LOG(DEBUG) << "The oldest block on device is "
+             << blocks_on_device_.begin()->first
+             << " sequence number : " << block_sequence_number_;
+  return the_oldest_block_on_device;
+}
+
 TemporalBlock *TemporalBlockAllocator::SwapBlockToHost(TemporalBlock *block) {
-  if (block_to_id_.find(block) == block_to_id_.end()) {
-    LOG(WARNING) << "Block not found in block_to_id_";
-    return nullptr;
-  }
+  CHECK_NOTNULL(block);
+  CHECK_NE(block_to_seq_.find(block), block_to_seq_.end());
+  CHECK_GT(block->size, 0);
 
-  auto block_id = block_to_id_[block];
-  if (block->size == 0) {
-    LOG(WARNING) << "Block " << block_id << " is empty";
-    return block;
-  }
+  auto block_id = block_to_seq_[block];
 
-  if (blocks_on_device_.find(block_id) == blocks_on_device_.end() &&
-      blocks_on_host_.find(block_id) != blocks_on_host_.end()) {
-    LOG(WARNING) << "Block " << block_id << " is already on host";
-    return block;
-  }
+  CHECK(blocks_on_device_.find(block_id) != blocks_on_device_.end() &&
+        blocks_on_host_.find(block_id) == blocks_on_host_.end());
 
   // allocate CPU memory for the block
   auto block_on_host = new TemporalBlock();
@@ -166,7 +166,7 @@ TemporalBlock *TemporalBlockAllocator::SwapBlockToHost(TemporalBlock *block) {
   {
     std::lock_guard<std::mutex> lock(mutex_);
     blocks_on_host_[block_id] = block_on_host;
-    block_to_id_[block_on_host] = block_id;
+    block_to_seq_[block_on_host] = block_id;
   }
 
   return block_on_host;

--- a/dgnn/csrc/temporal_block_allocator.h
+++ b/dgnn/csrc/temporal_block_allocator.h
@@ -70,14 +70,16 @@ class TemporalBlockAllocator {
   /**
    * @brief Align up a size to the min_block_size.
    *
-   * If the size is less than the min_block_size, it returns the min_block_size. If not,
-   * it rounds up the size to the next power of two.
+   * If the size is less than the min_block_size, it returns the min_block_size.
+   * If not, it rounds up the size to the next power of two.
    *
    * @param size The size to align up.
    *
    * @return The aligned size.
    */
   std::size_t AlignUp(std::size_t size);
+
+  TemporalBlock* GetTheOldestBlockOnDevice() const;
 
   std::size_t num_blocks_on_device() const;
   std::size_t num_blocks_on_host() const;
@@ -93,14 +95,14 @@ class TemporalBlockAllocator {
   std::size_t min_block_size_;
   std::stack<rmm::mr::device_memory_resource*> gpu_resources_;
 
-  // id -> block raw pointer
+  // sequence number -> block raw pointer
   std::map<uint64_t, TemporalBlock*> blocks_on_device_;
   std::map<uint64_t, TemporalBlock*> blocks_on_host_;
 
-  std::unordered_map<TemporalBlock*, uint64_t> block_to_id_;
+  std::unordered_map<TemporalBlock*, uint64_t> block_to_seq_;
 
   // a monotonically increasing sequence number
-  uint64_t block_id_counter_;
+  uint64_t block_sequence_number_;
 
   std::mutex mutex_;
 };


### PR DESCRIPTION
**Context**: previously we swap the blocks from source node 0. So the blocks of source node 0 are always the first to be swapped, which is not what we want. 

**Method**:  Maintain a sequence number in `TemporalBlockAllocator`.  The sequence number increase monotonously when creating a block. So the oldest block is the one with the smallest sequence number. 

```cpp
auto the_oldest_block_on_device = blocks_on_device_.begin()->second;
```

This line will get the oldest block because `std::map` has sorted the items in ascending order internally. 