### PR TITLE
fix: swap func and move funcs to utils

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # set cuda arch
+set(CMAKE_CUDA_RUNTIME_LIBRARY Shared)
 include(FindCUDA/select_compute_arch)
 CUDA_DETECT_INSTALLED_GPUS(INSTALLED_GPU_CCS_1)
 string(STRIP "${INSTALLED_GPU_CCS_1}" INSTALLED_GPU_CCS_2)
@@ -15,6 +16,7 @@ string(REPLACE " " ";" INSTALLED_GPU_CCS_3 "${INSTALLED_GPU_CCS_2}")
 string(REPLACE "." "" CUDA_ARCH_LIST "${INSTALLED_GPU_CCS_3}")
 SET(CMAKE_CUDA_ARCHITECTURES ${CUDA_ARCH_LIST})
 message(STATUS "CUDA_ARCH_LIST: ${CUDA_ARCH_LIST}")
+
 
 
 # rmm
@@ -44,6 +46,8 @@ pybind11_add_module(${TARGET_LIB} ${DGNN_SRC_FILES})
 target_compile_options(${TARGET_LIB} PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:
     --generate-line-info
     --use_fast_math
+    -rdc=true
     >)
 
+set_property(TARGET ${TARGET_LIB} PROPERTY CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 

--- a/dgnn/csrc/sampling_kernels.cu
+++ b/dgnn/csrc/sampling_kernels.cu
@@ -2,46 +2,9 @@
 
 #include "common.h"
 #include "sampling_kernels.h"
+#include "utils.h"
 
 namespace dgnn {
-
-__host__ __device__ void LowerBound(TimestampType* timestamps, int num_edges,
-                                    TimestampType timestamp, int* idx) {
-  int left = 0;
-  int right = num_edges;
-  while (left < right) {
-    int mid = (left + right) / 2;
-    if (timestamps[mid] < timestamp) {
-      left = mid + 1;
-    } else {
-      right = mid;
-    }
-  }
-  *idx = left;
-}
-
-template <typename T>
-__device__ void inline swap(T a, T b) {
-  T c(a);
-  a = b;
-  b = c;
-}
-
-__device__ void QuickSort(uint32_t* indices, int lo, int hi) {
-  if (lo >= hi || lo < 0 || hi < 0) return;
-
-  uint32_t pivot = indices[hi];
-  int i = lo - 1;
-  for (int j = lo; j < hi; ++j) {
-    if (indices[j] < pivot) {
-      swap(indices[++i], indices[j]);
-    }
-  }
-  swap(indices[++i], indices[hi]);
-
-  QuickSort(indices, lo, i - 1);
-  QuickSort(indices, i + 1, hi);
-}
 
 __global__ void SampleLayerRecentKernel(
     const DoublyLinkedList* node_table, std::size_t num_nodes, bool prop_time,

--- a/dgnn/csrc/utils.cu
+++ b/dgnn/csrc/utils.cu
@@ -81,4 +81,43 @@ __global__ void InitCuRandStates(curandState_t* states, uint64_t seed) {
   curand_init(seed, tid, 0, &states[tid]);
 }
 
+__host__ __device__ void LowerBound(TimestampType* timestamps, int num_edges,
+                                    TimestampType timestamp, int* idx) {
+  int left = 0;
+  int right = num_edges;
+  while (left < right) {
+    int mid = (left + right) / 2;
+    if (timestamps[mid] < timestamp) {
+      left = mid + 1;
+    } else {
+      right = mid;
+    }
+  }
+  *idx = left;
+}
+
+template <typename T>
+__host__ __device__ void inline swap(T& a, T& b) {
+  T c(a);
+  a = b;
+  b = c;
+}
+
+__host__ __device__ void QuickSort(uint32_t* indices, int lo, int hi) {
+  if (lo >= hi || lo < 0 || hi < 0) return;
+
+  uint32_t pivot = indices[hi];
+  int i = lo - 1;
+  for (int j = lo; j < hi; ++j) {
+    if (indices[j] < pivot) {
+      swap(indices[++i], indices[j]);
+    }
+  }
+  swap(indices[++i], indices[hi]);
+
+  QuickSort(indices, lo, i - 1);
+  QuickSort(indices, i + 1, hi);
+}
+
+
 }  // namespace dgnn

--- a/dgnn/csrc/utils.h
+++ b/dgnn/csrc/utils.h
@@ -75,6 +75,10 @@ void Copy(void* dst, const void* src, std::size_t size);
 
 __global__ void InitCuRandStates(curandState_t* state, uint64_t seed);
 
+__host__ __device__ void LowerBound(TimestampType* timestamps, int num_edges,
+                                    TimestampType timestamp, int* idx);
+
+__host__ __device__ void QuickSort(uint32_t* indices, int lo, int hi);
 }  // namespace dgnn
 
 #endif  // DGNN_UTILS_H_


### PR DESCRIPTION
1. fix swap function. pass by reference. 
2. move utility functions in `sampling_kernels.cu` to `utils.cu`. need to update the compile options in CMakeLists.txt. 