### PR TITLE
fix: disable reorder when random_size == 0

### DIFF
--- a/dgnn/data.py
+++ b/dgnn/data.py
@@ -103,7 +103,9 @@ class RandomStartBatchSampler(BatchSampler):
     def reset(self):
         self.reorder = self.num_chunks > 1
         l = self.batch_size // self.chunk_size
-        self.random_size = random.randint(0, l - 1) * self.chunk_size
+        self.random_size = int(random.randint(0, l - 1) * self.chunk_size)
+        if self.random_size == 0:
+            self.reorder = False
 
 
 class DistributedBatchSampler(BatchSampler):


### PR DESCRIPTION
https://github.com/jasperzhong/dynamic-graph-neural-network/blob/3bddb875fc30eece75ef76b36c876c112b06a578/dgnn/data.py#L86-L106

if `sellf.random_size == 0` and `self.reorder == True`, then `if len(batch) == self.random_size: ` would always be false and the whole dataset would be formed into one batch. 