### PR TITLE
fix: TGN uses updated memory for supporting nodes as input

### DIFF
--- a/gnnflow/models/modules/memory.py
+++ b/gnnflow/models/modules/memory.py
@@ -154,15 +154,13 @@ class Memory:
                 `b.srcdata['ts']` is the time stamps of all nodes.
         """
         device = b.device
-        num_dst_nodes = b.num_dst_nodes()
-        target_nodes = b.srcdata['ID'][:num_dst_nodes]
         all_nodes = b.srcdata['ID']
         assert isinstance(all_nodes, torch.Tensor)
 
         b.srcdata['mem'] = self.node_memory[all_nodes].to(device)
-        b.dstdata['mem_ts'] = self.node_memory_ts[target_nodes].to(device)
-        b.dstdata['mail_ts'] = self.mailbox_ts[target_nodes].to(device)
-        b.dstdata['mem_input'] = self.mailbox[target_nodes].to(device)
+        b.srcdata['mem_ts'] = self.node_memory_ts[all_nodes].to(device)
+        b.srcdata['mail_ts'] = self.mailbox_ts[all_nodes].to(device)
+        b.srcdata['mem_input'] = self.mailbox[all_nodes].to(device)
 
     def update_memory(self, last_updated_nid: torch.Tensor,
                       last_updated_memory: torch.Tensor,

--- a/scripts/offline_edge_prediction.py
+++ b/scripts/offline_edge_prediction.py
@@ -172,15 +172,12 @@ def main():
     dgraph = build_dynamic_graph(
         **data_config, device=args.local_rank, dataset_df=full_data)
 
-    num_nodes = dgraph.num_vertices()
-    num_edges = dgraph.num_edges()
+    num_nodes = dgraph.num_vertices() + 1
+    num_edges = dgraph.num_edges() 
     # put the features in shared memory when using distributed training
     node_feats, edge_feats = load_feat(
         args.data, shared_memory=args.distributed,
         local_rank=args.local_rank, local_world_size=args.local_world_size)
-
-    edge_feats = torch.randn(672447, 172)
-    node_feats = torch.randn(10985, 172)
 
     dim_node = 0 if node_feats is None else node_feats.shape[1]
     dim_edge = 0 if edge_feats is None else edge_feats.shape[1]


### PR DESCRIPTION
TGN uses updated memory for supporting nodes as input, but only the memory of root nodes are written into the memory.
![TGN-REDDIT-LRUCache-0 2_fix](https://user-images.githubusercontent.com/25879526/195003606-01135325-984f-4a30-af02-da7dd0c436d5.png)

