### PR TITLE
fix: dist datasampler local_world_size problem

### DIFF
--- a/gnnflow/csrc/dynamic_graph.cu
+++ b/gnnflow/csrc/dynamic_graph.cu
@@ -81,10 +81,6 @@ void DynamicGraph::AddEdges(const std::vector<NIDType>& src_nodes,
   CHECK_EQ(src_nodes.size(), timestamps.size());
   CHECK_EQ(src_nodes.size(), eids.size());
 
-  int device;
-  CUDA_CALL(cudaGetDevice(&device));
-  LOG(DEBUG) << "device: " << device << " graph device: " << device_;
-
   // NB: it seems to be necessary to set the device again.
   CUDA_CALL(cudaSetDevice(device_));
 

--- a/gnnflow/data.py
+++ b/gnnflow/data.py
@@ -10,7 +10,7 @@ import torch.distributed
 from torch._six import string_classes
 from torch.utils.data import BatchSampler, Dataset, Sampler
 
-from gnnflow.utils import RandEdgeSampler
+from gnnflow.utils import RandEdgeSampler, local_rank
 
 np_str_obj_array_pattern = re.compile(r'[SaUO]')
 
@@ -133,7 +133,7 @@ class DistributedBatchSampler(BatchSampler):
                                                       drop_last)
         self.rank = rank
         self.world_size = world_size
-        self.local_rank = rank % torch.cuda.device_count()
+        self.local_rank = local_rank()
         self.device = torch.device('cuda', self.local_rank)
         assert 0 < num_chunks < batch_size, "num_chunks must be in (0, batch_size)"
 

--- a/gnnflow/distributed/dispatcher.py
+++ b/gnnflow/distributed/dispatcher.py
@@ -9,7 +9,7 @@ import torch.distributed.rpc as rpc
 
 import gnnflow.distributed.graph_services as graph_services
 from gnnflow.distributed.partition import get_partitioner
-from gnnflow.distributed.utils import local_world_size
+from gnnflow.utils import local_world_size
 
 global dispatcher
 dispatcher = None

--- a/gnnflow/distributed/dist_context.py
+++ b/gnnflow/distributed/dist_context.py
@@ -44,7 +44,7 @@ def initialize(rank: int, world_size: int, dataset: pd.DataFrame,
                                    undirected, node_feats, edge_feats)
 
     # wait and check
-    torch.distributed.all_reduce(torch.tensor(1).cuda())
+    torch.distributed.barrier()
     logging.info("Rank %d: Number of vertices: %d, number of edges: %d",
                  rank, graph_services.num_vertices(), graph_services.num_edges())
     logging.info("Rank %d: partition table shape: %s",

--- a/gnnflow/distributed/dist_context.py
+++ b/gnnflow/distributed/dist_context.py
@@ -44,7 +44,7 @@ def initialize(rank: int, world_size: int, dataset: pd.DataFrame,
                                    undirected, node_feats, edge_feats)
 
     # wait and check
-    torch.distributed.barrier()
+    torch.distributed.all_reduce(torch.tensor(1).cuda())
     logging.info("Rank %d: Number of vertices: %d, number of edges: %d",
                  rank, graph_services.num_vertices(), graph_services.num_edges())
     logging.info("Rank %d: partition table shape: %s",

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import threading
 import time
 from queue import Queue
@@ -16,7 +15,7 @@ import gnnflow.distributed.graph_services as graph_services
 from gnnflow import TemporalSampler
 from gnnflow.distributed.common import SamplingResultTorch
 from gnnflow.distributed.dist_graph import DistributedDynamicGraph
-from gnnflow.distributed.utils import local_rank, local_world_size
+from gnnflow.utils import local_rank, local_world_size
 from libgnnflow import SamplingResult
 
 
@@ -137,6 +136,7 @@ class DistributedTemporalSampler:
                 timestamps[partition_mask]).contiguous()
 
             worker_rank = partition_id * self._local_world_size + self._local_rank
+            logging.debug("call remote sample_layer_local on worker %d", worker_rank)
             if worker_rank == self._rank:
                 futures.append(graph_services.sample_layer_local(partition_vertices, partition_timestamps,
                                                                  layer, snapshot))

--- a/gnnflow/distributed/partition.py
+++ b/gnnflow/distributed/partition.py
@@ -1,4 +1,3 @@
-import logging
 from typing import List, NamedTuple
 
 import numpy as np

--- a/gnnflow/distributed/utils.py
+++ b/gnnflow/distributed/utils.py
@@ -1,21 +1,6 @@
 from collections import defaultdict
-import os
 from enum import Enum
 from threading import Lock
-import torch
-import torch.distributed
-
-
-def local_world_size():
-    return int(os.environ["LOCAL_WORLD_SIZE"])
-
-
-def local_rank():
-    return int(os.environ["LOCAL_RANK"])
-
-
-def rank():
-    return torch.distributed.get_rank()
 
 
 class WorkStatus(Enum):

--- a/gnnflow/models/modules/memory.py
+++ b/gnnflow/models/modules/memory.py
@@ -9,8 +9,9 @@ from typing import Dict, Optional, Union
 import torch
 import torch.distributed
 from dgl.heterograph import DGLBlock
-
 from dgl.utils.shared_mem import create_shared_mem_array, get_shared_mem_array
+
+from gnnflow.utils import local_rank, local_world_size
 
 
 class Memory:
@@ -41,8 +42,8 @@ class Memory:
         self.device = device
 
         if shared_memory:
-            local_world_size = torch.cuda.device_count()
-            local_rank = torch.distributed.get_rank() % local_world_size
+            local_world_size = local_world_size()
+            local_rank = local_rank()
         else:
             local_world_size = 1
             local_rank = 0

--- a/gnnflow/utils.py
+++ b/gnnflow/utils.py
@@ -13,6 +13,18 @@ from dgl.utils.shared_mem import create_shared_mem_array, get_shared_mem_array
 from .dynamic_graph import DynamicGraph
 
 
+def local_world_size():
+    return int(os.environ["LOCAL_WORLD_SIZE"])
+
+
+def local_rank():
+    return int(os.environ["LOCAL_RANK"])
+
+
+def rank():
+    return torch.distributed.get_rank()
+
+
 def get_project_root_dir() -> str:
     return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/scripts/offline_edge_prediction_multi_node.py
+++ b/scripts/offline_edge_prediction_multi_node.py
@@ -65,7 +65,7 @@ parser.add_argument("--partition-strategy", type=str, default="roundrobin",
                     help="partition strategy for distributed training")
 args = parser.parse_args()
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.DEBUG)
 logging.info(args)
 
 checkpoint_path = os.path.join(get_project_root_dir(),

--- a/scripts/run_offline_multi_node.sh
+++ b/scripts/run_offline_multi_node.sh
@@ -33,7 +33,6 @@ cmd="torchrun \
     --partition --ingestion-batch-size 100000 \
     --partition-strategy $PARTITION_STRATEGY"
 
-
 echo $cmd
 NCCL_IB_DISABLE=1 NCCL_DEBUG=INFO CUDA_LAUNCH_BLOCKING=1 LOGLEVEL=DEBUG OMP_NUM_THREADS=8 exec $cmd
 

--- a/scripts/run_offline_multi_node.sh
+++ b/scripts/run_offline_multi_node.sh
@@ -10,7 +10,7 @@ PARTITION_STRATEGY="${5:-hash}"
 HOST_NODE_ADDR=10.28.1.16
 HOST_NODE_PORT=29400
 NNODES=2
-NPROC_PER_NODE=2
+NPROC_PER_NODE=1
 
 CURRENT_NODE_IP=$(ip -4 a show dev ${INTERFACE} | grep inet | cut -d " " -f6 | cut -d "/" -f1)
 if [ $CURRENT_NODE_IP = $HOST_NODE_ADDR ]; then

--- a/scripts/run_offline_multi_node.sh
+++ b/scripts/run_offline_multi_node.sh
@@ -10,7 +10,7 @@ PARTITION_STRATEGY="${5:-hash}"
 HOST_NODE_ADDR=10.28.1.16
 HOST_NODE_PORT=29400
 NNODES=2
-NPROC_PER_NODE=1
+NPROC_PER_NODE=2
 
 CURRENT_NODE_IP=$(ip -4 a show dev ${INTERFACE} | grep inet | cut -d " " -f6 | cut -d "/" -f1)
 if [ $CURRENT_NODE_IP = $HOST_NODE_ADDR ]; then


### PR DESCRIPTION
Don't use torch.cuda.get_device_count() as local_world_size anymore. Use `local_rank` and `local_world_size` in the utils instead. 