### PR TITLE
feat: dist kvstore

### DIFF
--- a/gnnflow/cache/cache.py
+++ b/gnnflow/cache/cache.py
@@ -318,26 +318,6 @@ class Cache:
                     uncached_mask = ~cache_mask
                     uncached_edge_id = edges[uncached_mask]
 
-                    # get the first_indices of the origin tensor in unique
-                    # pytorch should have this option like numpy !!
-                    uncached_edge_id_unique, uncached_edge_id_unique_index, counts = torch.unique(
-                        uncached_edge_id, return_inverse=True, return_counts=True)
-                    _, ind_sorted = torch.sort(
-                        uncached_edge_id_unique_index, stable=True)
-                    cum_sum = counts.cumsum(0)
-                    cum_sum = torch.cat(
-                        (torch.tensor([0]).cuda(), cum_sum[:-1]))
-                    first_indicies = ind_sorted[cum_sum]
-
-                    # uncached_edge_id_unique_index.sort()
-                    src_eid_index = torch.unique(
-                        uncached_edge_id_unique_index)
-                    uncached_edge_id_unique = uncached_edge_id_unique[src_eid_index]
-                    src_nid = b.srcdata['ID'][b.edges()[1]]
-
-                    uncached_eid_to_nid = src_nid[uncached_mask]
-                    uncached_eid_to_nid_unique = uncached_eid_to_nid[src_eid_index].cpu(
-                    )
                     if self.distributed:
                         # edge_features need to convert to nid first.
                         # get the first_indices of the origin tensor in unique

--- a/gnnflow/cache/cache.py
+++ b/gnnflow/cache/cache.py
@@ -327,7 +327,7 @@ class Cache:
                             src_nid.shape))
                         # TODO: torch doesn't keep order when using unique
                         _, idx = np.unique(
-                            uncached_edge_id_unique_index.to_numpy(), return_index=True)
+                            uncached_edge_id_unique_index.numpy(), return_index=True)
                         src_eid_index = uncached_edge_id_unique_index[np.sort(
                             idx)]
                         # src_eid_index = torch.unique_consecutive(

--- a/gnnflow/cache/cache.py
+++ b/gnnflow/cache/cache.py
@@ -338,12 +338,12 @@ class Cache:
                         if self.pinned_efeat_buffs is not None:
                             self.pinned_efeat_buffs[
                                 i][:uncached_edge_id_unique.shape[0]] = self.kvstore_client.pull(
-                                    uncached_edge_id_unique, mode='edge', nid=uncached_eid_to_nid_unique)
+                                    uncached_edge_id_unique.cpu(), mode='edge', nid=uncached_eid_to_nid_unique)
                             uncached_edge_feature = self.pinned_efeat_buffs[i][:uncached_edge_id_unique.shape[0]].to(
                                 self.device, non_blocking=True)
                         else:
                             uncached_edge_feature = self.kvstore_client.pull(
-                                uncached_edge_id_unique, mode='edge', nid=uncached_eid_to_nid_unique)
+                                uncached_edge_id_unique.cpu(), mode='edge', nid=uncached_eid_to_nid_unique)
                     else:
                         if self.pinned_efeat_buffs is not None:
                             torch.index_select(self.edge_feats, 0, uncached_edge_id_unique.to('cpu'),

--- a/gnnflow/cache/cache.py
+++ b/gnnflow/cache/cache.py
@@ -325,11 +325,12 @@ class Cache:
                         src_nid = b.srcdata['ID'][b.edges()[1]]
                         logging.info("src_nid: {}".format(
                             src_nid.shape))
-                        # TODO: torch doesn't keep order when using unique                     
+                        # TODO: torch doesn't keep order when using unique
                         _, idx = np.unique(
                             uncached_edge_id_unique_index.cpu().numpy(), return_index=True)
                         src_eid_index = uncached_edge_id_unique_index[np.sort(
                             idx)]
+                        src_eid_index = torch.tensor(src_eid_index).cuda()
                         # src_eid_index = torch.unique_consecutive(
                         #     uncached_edge_id_unique_index)
                         logging.info("uncached_edge_id_unique_index: {}".format(

--- a/gnnflow/cache/cache.py
+++ b/gnnflow/cache/cache.py
@@ -326,8 +326,14 @@ class Cache:
                             src_nid.shape))
                         src_eid_index = torch.unique_consecutive(
                             uncached_edge_id_unique_index)
+                        logging.info("uncached_edge_id_unique_index: {}".format(
+                            uncached_edge_id_unique_index.shape))
+                        logging.info("uncached_edge_id_unique_index: {}".format(
+                            uncached_edge_id_unique_index))
                         logging.info("src_eid_index: {}".format(
                             src_eid_index.shape))
+                        logging.info("src_eid_index: {}".format(
+                            src_eid_index))
                         uncached_eid_to_nid = src_nid[uncached_mask]
                         logging.info("uncached_eid_to_nid: {}".format(
                             uncached_eid_to_nid.shape))

--- a/gnnflow/cache/cache.py
+++ b/gnnflow/cache/cache.py
@@ -318,17 +318,43 @@ class Cache:
                     uncached_mask = ~cache_mask
                     uncached_edge_id = edges[uncached_mask]
 
+                    # get the first_indices of the origin tensor in unique
+                    # pytorch should have this option like numpy !!
+                    uncached_edge_id_unique, uncached_edge_id_unique_index, counts = torch.unique(
+                        uncached_edge_id, return_inverse=True, return_counts=True)
+                    _, ind_sorted = torch.sort(
+                        uncached_edge_id_unique_index, stable=True)
+                    cum_sum = counts.cumsum(0)
+                    cum_sum = torch.cat(
+                        (torch.tensor([0]).cuda(), cum_sum[:-1]))
+                    first_indicies = ind_sorted[cum_sum]
+
+                    # uncached_edge_id_unique_index.sort()
+                    src_eid_index = torch.unique(
+                        uncached_edge_id_unique_index)
+                    uncached_edge_id_unique = uncached_edge_id_unique[src_eid_index]
+                    src_nid = b.srcdata['ID'][b.edges()[1]]
+
+                    uncached_eid_to_nid = src_nid[uncached_mask]
+                    uncached_eid_to_nid_unique = uncached_eid_to_nid[src_eid_index].cpu(
+                    )
                     if self.distributed:
                         # edge_features need to convert to nid first.
-                        uncached_edge_id_unique, uncached_edge_id_unique_index = torch.unique(
-                            uncached_edge_id, return_inverse=True)
-                        src_eid_index = torch.unique(
-                            uncached_edge_id_unique_index)
-                        uncached_edge_id_unique = uncached_edge_id_unique[src_eid_index]
-                        src_nid = b.srcdata['ID'][b.edges()[1]]
+                        # get the first_indices of the origin tensor in unique
+                        # pytorch should have this option like numpy !!
+                        uncached_edge_id_unique, uncached_edge_id_unique_index, counts = torch.unique(
+                            uncached_edge_id, return_inverse=True, return_counts=True)
+                        _, ind_sorted = torch.sort(
+                            uncached_edge_id_unique_index, stable=True)
+                        cum_sum = counts.cumsum(0)
+                        cum_sum = torch.cat(
+                            (torch.tensor([0]).cuda(), cum_sum[:-1]))
+                        first_indicies = ind_sorted[cum_sum]
 
+                        src_nid = b.srcdata['ID'][b.edges()[1]]
                         uncached_eid_to_nid = src_nid[uncached_mask]
-                        uncached_eid_to_nid_unique = uncached_eid_to_nid[src_eid_index].cpu(
+                        # use the same indices as eid when unique
+                        uncached_eid_to_nid_unique = uncached_eid_to_nid[first_indicies].cpu(
                         )
                         if self.pinned_efeat_buffs is not None:
                             self.pinned_efeat_buffs[

--- a/gnnflow/cache/cache.py
+++ b/gnnflow/cache/cache.py
@@ -331,7 +331,8 @@ class Cache:
                         src_eid_index = uncached_edge_id_unique_index[np.sort(
                             idx)]
                         uncached_eid_to_nid = src_nid[uncached_mask]
-                        uncached_eid_to_nid_unique = uncached_eid_to_nid[src_eid_index]
+                        uncached_eid_to_nid_unique = uncached_eid_to_nid[src_eid_index].cpu(
+                        )
                         logging.info("uncached_eid_to_nid_unique: {}".format(
                             uncached_eid_to_nid_unique))
                         if self.pinned_efeat_buffs is not None:

--- a/gnnflow/cache/cache.py
+++ b/gnnflow/cache/cache.py
@@ -263,7 +263,6 @@ class Cache:
                 if self.distributed:
                     if self.pinned_nfeat_buffs is not None:
                         # TODO: maybe fetch local and remote features separately
-                        # TODO: may need .to('cpu')
                         self.pinned_nfeat_buffs[
                             i][:uncached_node_id_unique.shape[0]] = self.kvstore_client.pull(
                             uncached_node_id_unique, mode='node')
@@ -318,8 +317,6 @@ class Cache:
                     uncached_mask = ~cache_mask
                     uncached_edge_id = edges[uncached_mask]
 
-                    assert len(uncached_edge_id) > 0 or (len(
-                        uncached_edge_id) == 0 and cache_mask.sum() == len(edges)), "BUG!!!"
                     if len(uncached_edge_id) > 0:
                         if self.distributed:
                             # edge_features need to convert to nid first.
@@ -382,113 +379,5 @@ class Cache:
                         eid, mode='edge', nid=nid)
                 else:
                     self.target_edge_features = self.edge_feats[eid]
-
-        return mfgs
-
-    def fetch_feature_distributed(self, mfgs: List[List[DGLBlock]], update_cache: bool = True):
-        """Fetching the node/edge features of input_node_ids in distributed setting
-
-        Args:
-            mfgs: message-passing flow graphs
-            update_cache: whether to update the cache
-
-        Returns:
-            mfgs: message-passing flow graphs with node/edge features
-        """
-        if self.dim_edge_feat != 0:
-            i = 0
-            hit_ratio_sum = 0
-            for b in mfgs[0]:
-                nodes = b.srcdata['ID']
-                assert isinstance(nodes, torch.Tensor)
-                cache_mask = self.cache_node_flag[nodes]
-
-                hit_ratio = torch.sum(cache_mask) / len(nodes)
-                hit_ratio_sum += hit_ratio
-
-                node_feature = torch.zeros(
-                    len(nodes), self.dim_node_feat, dtype=torch.float32, device=self.device)
-
-                # fetch the cached features
-                cached_node_index = self.cache_node_map[nodes[cache_mask]]
-                node_feature[cache_mask] = self.cache_node_buffer[cached_node_index]
-                # fetch the uncached features
-                uncached_mask = ~cache_mask
-                uncached_node_id = nodes[uncached_mask]
-                uncached_node_id_unique, uncached_node_id_unique_index = torch.unique(
-                    uncached_node_id, return_inverse=True)
-
-                if self.pinned_nfeat_buffs is not None:
-                    # TODO: maybe fetch local and remote features separately
-                    # TODO: may need .to('cpu')
-                    self.pinned_nfeat_buffs[
-                        i][:uncached_node_id_unique.shape[0]] = self.kvstore_client.pull(
-                        uncached_node_id_unique, mode='node')
-                    uncached_node_feature = self.pinned_nfeat_buffs[i][:uncached_node_id_unique.shape[0]].to(
-                        self.device, non_blocking=True)
-                else:
-                    uncached_node_feature = self.kvstore_client.pull(
-                        uncached_node_id_unique, mode='node')
-
-                node_feature[uncached_mask] = uncached_node_feature[uncached_node_id_unique_index]
-
-                i += 1
-                b.srcdata['h'] = node_feature
-
-                if update_cache:
-                    # TODO: all update cache need rewrite
-                    self.update_node_cache(cached_node_index=cached_node_index,
-                                           uncached_node_id=uncached_node_id_unique,
-                                           uncached_node_feature=uncached_node_feature)
-
-            self.cache_node_ratio = hit_ratio_sum / i if i > 0 else 0
-
-        # Edge feature
-        if self.dim_edge_feat != 0:
-            i = 0
-            hit_ratio_sum = 0
-            for mfg in mfgs:
-                for b in mfg:
-                    edges = b.edata['ID']
-                    assert isinstance(edges, torch.Tensor)
-                    if len(edges) == 0:
-                        continue
-
-                    cache_mask = self.cache_edge_flag[edges]
-                    hit_ratio = torch.sum(cache_mask) / len(edges)
-                    hit_ratio_sum += hit_ratio
-
-                    edge_feature = torch.zeros(len(edges), self.dim_edge_feat,
-                                               dtype=torch.float32, device=self.device)
-
-                    # fetch the cached features
-                    cached_edge_index = self.cache_edge_map[edges[cache_mask]]
-                    edge_feature[cache_mask] = self.cache_edge_buffer[cached_edge_index]
-                    # fetch the uncached features
-                    uncached_mask = ~cache_mask
-                    uncached_edge_id = edges[uncached_mask]
-                    uncached_edge_id_unique, uncached_edge_id_unique_index = torch.unique(
-                        uncached_edge_id, return_inverse=True)
-
-                    if self.pinned_efeat_buffs is not None:
-                        self.pinned_efeat_buffs[
-                            i][:uncached_edge_id_unique.shape[0]] = self.kvstore_client.pull(
-                                uncached_edge_id_unique, mode='edge')
-                        uncached_edge_feature = self.pinned_efeat_buffs[i][:uncached_edge_id_unique.shape[0]].to(
-                            self.device, non_blocking=True)
-                    else:
-                        uncached_edge_feature = self.kvstore_client.pull(
-                            uncached_edge_id_unique, mode='edge')
-                    edge_feature[uncached_mask] = uncached_edge_feature[uncached_edge_id_unique_index]
-
-                    i += 1
-                    b.edata['f'] = edge_feature
-
-                    if update_cache:
-                        self.update_edge_cache(cached_edge_index=cached_edge_index,
-                                               uncached_edge_id=uncached_edge_id_unique,
-                                               uncached_edge_feature=uncached_edge_feature)
-
-            self.cache_edge_ratio = hit_ratio_sum / i if i > 0 else 0
 
         return mfgs

--- a/gnnflow/cache/cache.py
+++ b/gnnflow/cache/cache.py
@@ -320,11 +320,11 @@ class Cache:
 
                     if self.distributed:
                         # edge_features need to convert to nid first.
-                        _, uncached_edge_id_unique_index = torch.unique(
+                        uncached_edge_id_unique, uncached_edge_id_unique_index = torch.unique(
                             uncached_edge_id, return_inverse=True)
                         src_eid_index = torch.unique(
                             uncached_edge_id_unique_index)
-                        uncached_edge_id_unique = uncached_edge_id[src_eid_index]
+                        uncached_edge_id_unique = uncached_edge_id_unique[src_eid_index]
                         src_nid = b.srcdata['ID'][b.edges()[1]]
 
                         uncached_eid_to_nid = src_nid[uncached_mask]

--- a/gnnflow/cache/cache.py
+++ b/gnnflow/cache/cache.py
@@ -312,6 +312,7 @@ class Cache:
                     # fetch the uncached features
                     uncached_mask = ~cache_mask
                     uncached_edge_id = edges[uncached_mask]
+                    logging.info("uncached_mask: {}".format(uncached_mask))
                     logging.info("uncached_edge_id: {}".format(
                         uncached_edge_id.shape))
                     uncached_edge_id_unique, uncached_edge_id_unique_index = torch.unique(
@@ -325,6 +326,8 @@ class Cache:
                             src_nid.shape))
                         src_eid_index = torch.unique_consecutive(
                             uncached_edge_id_unique_index)
+                        logging.info("src_eid_index: {}".format(
+                            src_eid_index.shape))
                         uncached_eid_to_nid = src_nid[uncached_mask]
                         logging.info("uncached_eid_to_nid: {}".format(
                             uncached_eid_to_nid.shape))

--- a/gnnflow/cache/cache.py
+++ b/gnnflow/cache/cache.py
@@ -312,15 +312,22 @@ class Cache:
                     # fetch the uncached features
                     uncached_mask = ~cache_mask
                     uncached_edge_id = edges[uncached_mask]
+                    logging.info("uncached_edge_id: {}".format(
+                        uncached_edge_id.shape))
                     uncached_edge_id_unique, uncached_edge_id_unique_index = torch.unique(
                         uncached_edge_id, return_inverse=True)
-
+                    logging.info("uncached_edge_id_unique: {}".format(
+                        uncached_edge_id_unique.shape))
                     if self.distributed:
                         # edge_features need to convert to nid first.
                         src_nid = b.srcdata['ID'][b.edges()[1]]
+                        logging.info("src_nid: {}".format(
+                            src_nid.shape))
                         src_eid_index = torch.unique_consecutive(
                             uncached_edge_id_unique_index)
                         uncached_eid_to_nid = src_nid[uncached_mask]
+                        logging.info("uncached_eid_to_nid: {}".format(
+                            uncached_eid_to_nid.shape))
                         uncached_eid_to_nid_unique = uncached_eid_to_nid[src_eid_index]
                         logging.info("uncached_eid_to_nid_unique: {}".format(
                             uncached_eid_to_nid_unique.shape))

--- a/gnnflow/cache/cache.py
+++ b/gnnflow/cache/cache.py
@@ -4,6 +4,7 @@ import torch
 from dgl.heterograph import DGLBlock
 
 from gnnflow.distributed.kvstore import KVStoreClient
+import numpy as np
 
 
 class Cache:
@@ -324,8 +325,13 @@ class Cache:
                         src_nid = b.srcdata['ID'][b.edges()[1]]
                         logging.info("src_nid: {}".format(
                             src_nid.shape))
-                        src_eid_index = torch.unique_consecutive(
-                            uncached_edge_id_unique_index)
+                        # TODO: torch doesn't keep order when using unique
+                        _, idx = np.unique(
+                            uncached_edge_id_unique_index.to_numpy(), return_index=True)
+                        src_eid_index = uncached_edge_id_unique_index[np.sort(
+                            idx)]
+                        # src_eid_index = torch.unique_consecutive(
+                        #     uncached_edge_id_unique_index)
                         logging.info("uncached_edge_id_unique_index: {}".format(
                             uncached_edge_id_unique_index.shape))
                         logging.info("uncached_edge_id_unique_index: {}".format(

--- a/gnnflow/cache/cache.py
+++ b/gnnflow/cache/cache.py
@@ -330,27 +330,10 @@ class Cache:
                             uncached_edge_id_unique_index.cpu().numpy(), return_index=True)
                         src_eid_index = uncached_edge_id_unique_index[np.sort(
                             idx)]
-                        src_eid_index = torch.tensor(src_eid_index).cuda()
-                        # src_eid_index = torch.unique_consecutive(
-                        #     uncached_edge_id_unique_index)
-                        logging.info("uncached_edge_id_unique_index: {}".format(
-                            uncached_edge_id_unique_index.shape))
-                        logging.info("uncached_edge_id_unique_index: {}".format(
-                            uncached_edge_id_unique_index))
-                        logging.info("src_eid_index: {}".format(
-                            src_eid_index.shape))
-                        logging.info("src_eid_index: {}".format(
-                            src_eid_index))
                         uncached_eid_to_nid = src_nid[uncached_mask]
-                        logging.info("uncached_eid_to_nid: {}".format(
-                            uncached_eid_to_nid.shape))
                         uncached_eid_to_nid_unique = uncached_eid_to_nid[src_eid_index]
                         logging.info("uncached_eid_to_nid_unique: {}".format(
-                            uncached_eid_to_nid_unique.shape))
-                        logging.info("uncached_edge_id_unique: {}".format(
-                            uncached_edge_id_unique.shape))
-                        # src_nid = b.srcdata['ID'][uncached_mask][b.edges()[
-                        #     1][uncached_mask][src_eid_index]]
+                            uncached_eid_to_nid_unique))
                         if self.pinned_efeat_buffs is not None:
                             self.pinned_efeat_buffs[
                                 i][:uncached_edge_id_unique.shape[0]] = self.kvstore_client.pull(

--- a/gnnflow/cache/cache.py
+++ b/gnnflow/cache/cache.py
@@ -325,9 +325,9 @@ class Cache:
                         src_nid = b.srcdata['ID'][b.edges()[1]]
                         logging.info("src_nid: {}".format(
                             src_nid.shape))
-                        # TODO: torch doesn't keep order when using unique
+                        # TODO: torch doesn't keep order when using unique                     
                         _, idx = np.unique(
-                            uncached_edge_id_unique_index.numpy(), return_index=True)
+                            uncached_edge_id_unique_index.cpu().numpy(), return_index=True)
                         src_eid_index = uncached_edge_id_unique_index[np.sort(
                             idx)]
                         # src_eid_index = torch.unique_consecutive(

--- a/gnnflow/cache/cache.py
+++ b/gnnflow/cache/cache.py
@@ -318,6 +318,8 @@ class Cache:
                     uncached_mask = ~cache_mask
                     uncached_edge_id = edges[uncached_mask]
 
+                    assert len(uncached_edge_id) > 0 or (len(
+                        uncached_edge_id) == 0 and cache_mask.sum() == len(edges)), "BUG!!!"
                     if len(uncached_edge_id) > 0:
                         if self.distributed:
                             # edge_features need to convert to nid first.

--- a/gnnflow/cache/cache.py
+++ b/gnnflow/cache/cache.py
@@ -363,7 +363,7 @@ class Cache:
                 if self.distributed:
                     # TODO: maybe there are some edge_features is in the memory now
                     self.target_edge_features = self.kvstore_client.pull(
-                        eid, mode='edge')
+                        eid, mode='edge', nid=mfgs[-1][0].srcdata['ID'][:mfgs[-1][0].num_dst_nodes()])
                 else:
                     self.target_edge_features = self.edge_feats[eid]
 

--- a/gnnflow/cache/cache.py
+++ b/gnnflow/cache/cache.py
@@ -313,13 +313,9 @@ class Cache:
                     # fetch the uncached features
                     uncached_mask = ~cache_mask
                     uncached_edge_id = edges[uncached_mask]
-                    logging.info("uncached_mask: {}".format(uncached_mask))
-                    logging.info("uncached_edge_id: {}".format(
-                        uncached_edge_id.shape))
                     uncached_edge_id_unique, uncached_edge_id_unique_index = torch.unique(
                         uncached_edge_id, return_inverse=True)
-                    logging.info("uncached_edge_id_unique: {}".format(
-                        uncached_edge_id_unique.shape))
+
                     if self.distributed:
                         # edge_features need to convert to nid first.
                         src_nid = b.srcdata['ID'][b.edges()[1]]
@@ -333,8 +329,6 @@ class Cache:
                         uncached_eid_to_nid = src_nid[uncached_mask]
                         uncached_eid_to_nid_unique = uncached_eid_to_nid[src_eid_index].cpu(
                         )
-                        logging.info("uncached_eid_to_nid_unique: {}".format(
-                            uncached_eid_to_nid_unique))
                         if self.pinned_efeat_buffs is not None:
                             self.pinned_efeat_buffs[
                                 i][:uncached_edge_id_unique.shape[0]] = self.kvstore_client.pull(

--- a/gnnflow/cache/fifo_cache.py
+++ b/gnnflow/cache/fifo_cache.py
@@ -10,6 +10,7 @@ class FIFOCache(Cache):
     """
     First-in-first-out cache
     """
+
     def __init__(self, cache_ratio: int, num_nodes: int, num_edges: int,
                  device: Union[str, torch.device],
                  node_feats: Optional[torch.Tensor] = None,
@@ -19,7 +20,8 @@ class FIFOCache(Cache):
                  pinned_nfeat_buffs: Optional[torch.Tensor] = None,
                  pinned_efeat_buffs: Optional[torch.Tensor] = None,
                  kvstore_client: Optional[KVStoreClient] = None,
-                 distributed: Optional[bool] = False):
+                 distributed: Optional[bool] = False,
+                 neg_sample_ratio: Optional[int] = 1):
         """
         Initialize the cache
 
@@ -40,7 +42,7 @@ class FIFOCache(Cache):
         super(FIFOCache, self).__init__(cache_ratio, num_nodes, num_edges, device,
                                         node_feats, edge_feats, dim_node_feat, dim_edge_feat,
                                         pinned_nfeat_buffs, pinned_efeat_buffs,
-                                        kvstore_client, distributed)
+                                        kvstore_client, distributed, neg_sample_ratio)
         self.name = 'fifo'
         # pointer to the last entry for the recent cached nodes
         self.cache_node_pointer = 0
@@ -51,7 +53,7 @@ class FIFOCache(Cache):
         Init the cache with features
         """
         if self.distributed:
-            return 
+            return
         super(FIFOCache, self).init_cache(*args, **kwargs)
         if self.node_feats is not None:
             self.cache_node_pointer = self.node_capacity - 1

--- a/gnnflow/cache/fifo_cache.py
+++ b/gnnflow/cache/fifo_cache.py
@@ -38,6 +38,9 @@ class FIFOCache(Cache):
             pinned_nfeat_buffs: The pinned memory buffers for node features
             pinned_efeat_buffs: The pinned memory buffers for edge features
             kvstore_client: The KVStore_Client for fetching features when using distributed
+                    training
+            distributed: Whether to use distributed training
+            neg_sample_ratio: The ratio of negative samples to positive samples
         """
         super(FIFOCache, self).__init__(cache_ratio, num_nodes, num_edges, device,
                                         node_feats, edge_feats, dim_node_feat, dim_edge_feat,

--- a/gnnflow/cache/gnnlab_static_cache.py
+++ b/gnnflow/cache/gnnlab_static_cache.py
@@ -25,7 +25,8 @@ class GNNLabStaticCache(Cache):
                  pinned_nfeat_buffs: Optional[torch.Tensor] = None,
                  pinned_efeat_buffs: Optional[torch.Tensor] = None,
                  kvstore_client: Optional[KVStoreClient] = None,
-                 distributed: Optional[bool] = False):
+                 distributed: Optional[bool] = False,
+                 neg_sample_ratio: Optional[int] = 1):
         """
         Initialize the cache
 
@@ -49,7 +50,8 @@ class GNNLabStaticCache(Cache):
                                                 dim_node_feat, dim_edge_feat,
                                                 pinned_nfeat_buffs,
                                                 pinned_efeat_buffs,
-                                                kvstore_client, distributed)
+                                                kvstore_client, distributed,
+                                                neg_sample_ratio)
         # name
         self.name = 'gnnlab'
 

--- a/gnnflow/cache/gnnlab_static_cache.py
+++ b/gnnflow/cache/gnnlab_static_cache.py
@@ -43,6 +43,9 @@ class GNNLabStaticCache(Cache):
             pinned_nfeat_buffs: The pinned memory buffers for node features
             pinned_efeat_buffs: The pinned memory buffers for edge features
             kvstore_client: The KVStore_Client for fetching features when using distributed
+                    training
+            distributed: Whether to use distributed training
+            neg_sample_ratio: The ratio of negative samples to positive samples
         """
         super(GNNLabStaticCache, self).__init__(cache_ratio, num_nodes,
                                                 num_edges, device,

--- a/gnnflow/cache/lfu_cache.py
+++ b/gnnflow/cache/lfu_cache.py
@@ -20,7 +20,8 @@ class LFUCache(Cache):
                  pinned_nfeat_buffs: Optional[torch.Tensor] = None,
                  pinned_efeat_buffs: Optional[torch.Tensor] = None,
                  kvstore_client: Optional[KVStoreClient] = None,
-                 distributed: Optional[bool] = False):
+                 distributed: Optional[bool] = False,
+                 neg_sample_ratio: Optional[int] = 1):
         """
         Initialize the cache
 
@@ -43,7 +44,7 @@ class LFUCache(Cache):
                                        edge_feats, dim_node_feat,
                                        dim_edge_feat, pinned_nfeat_buffs,
                                        pinned_efeat_buffs, kvstore_client,
-                                       distributed)
+                                       distributed, neg_sample_ratio)
         self.name = 'lfu'
 
         if self.dim_node_feat != 0:
@@ -69,7 +70,7 @@ class LFUCache(Cache):
         Init the caching with features
         """
         if self.distributed:
-            return 
+            return
         super(LFUCache, self).init_cache(*args, **kwargs)
         if self.dim_node_feat != 0:
             self.cache_node_count[self.cache_index_to_node_id] += 1

--- a/gnnflow/cache/lru_cache.py
+++ b/gnnflow/cache/lru_cache.py
@@ -1,4 +1,3 @@
-from operator import neg
 from typing import Optional, Union
 
 import torch
@@ -39,6 +38,9 @@ class LRUCache(Cache):
             pinned_nfeat_buffs: The pinned memory buffers for node features
             pinned_efeat_buffs: The pinned memory buffers for edge features
             kvstore_client: The KVStore_Client for fetching features when using distributed
+                    training
+            distributed: Whether to use distributed training
+            neg_sample_ratio: The ratio of negative samples to positive samples
         """
         super(LRUCache, self).__init__(cache_ratio, num_nodes,
                                        num_edges, device, node_feats,

--- a/gnnflow/cache/lru_cache.py
+++ b/gnnflow/cache/lru_cache.py
@@ -71,6 +71,7 @@ class LRUCache(Cache):
         Reset the cache
         """
         # NB: only edge cache is reset
+        # TODO: reset logic may need some design for distributed
         if self.edge_feats is not None:
             cache_edge_id = torch.arange(
                 self.edge_capacity, dtype=torch.int64, device=self.device)

--- a/gnnflow/cache/lru_cache.py
+++ b/gnnflow/cache/lru_cache.py
@@ -1,3 +1,4 @@
+from operator import neg
 from typing import Optional, Union
 
 import torch
@@ -10,6 +11,7 @@ class LRUCache(Cache):
     """
     Least-recently-used (LRU) cache 
     """
+
     def __init__(self, cache_ratio: int, num_nodes: int, num_edges: int,
                  device: Union[str, torch.device],
                  node_feats: Optional[torch.Tensor] = None,
@@ -19,7 +21,8 @@ class LRUCache(Cache):
                  pinned_nfeat_buffs: Optional[torch.Tensor] = None,
                  pinned_efeat_buffs: Optional[torch.Tensor] = None,
                  kvstore_client: Optional[KVStoreClient] = None,
-                 distributed: Optional[bool] = False):
+                 distributed: Optional[bool] = False,
+                 neg_sample_ratio: Optional[int] = 1):
         """
         Initialize the cache
 
@@ -42,7 +45,7 @@ class LRUCache(Cache):
                                        edge_feats, dim_node_feat,
                                        dim_edge_feat, pinned_nfeat_buffs,
                                        pinned_efeat_buffs, kvstore_client,
-                                       distributed)
+                                       distributed, neg_sample_ratio)
         self.name = 'lru'
 
         if self.dim_node_feat != 0:

--- a/gnnflow/csrc/dynamic_graph.cu
+++ b/gnnflow/csrc/dynamic_graph.cu
@@ -81,10 +81,6 @@ void DynamicGraph::AddEdges(const std::vector<NIDType>& src_nodes,
   CHECK_EQ(src_nodes.size(), timestamps.size());
   CHECK_EQ(src_nodes.size(), eids.size());
 
-  int device;
-  CUDA_CALL(cudaGetDevice(&device));
-  LOG(DEBUG) << "device: " << device << " graph device: " << device_;
-
   // NB: it seems to be necessary to set the device again.
   CUDA_CALL(cudaSetDevice(device_));
 

--- a/gnnflow/data.py
+++ b/gnnflow/data.py
@@ -10,7 +10,7 @@ import torch.distributed
 from torch._six import string_classes
 from torch.utils.data import BatchSampler, Dataset, Sampler
 
-from gnnflow.utils import RandEdgeSampler
+from gnnflow.utils import RandEdgeSampler, local_rank
 
 np_str_obj_array_pattern = re.compile(r'[SaUO]')
 
@@ -133,7 +133,7 @@ class DistributedBatchSampler(BatchSampler):
                                                       drop_last)
         self.rank = rank
         self.world_size = world_size
-        self.local_rank = rank % torch.cuda.device_count()
+        self.local_rank = local_rank()
         self.device = torch.device('cuda', self.local_rank)
         assert 0 < num_chunks < batch_size, "num_chunks must be in (0, batch_size)"
 

--- a/gnnflow/distributed/dispatcher.py
+++ b/gnnflow/distributed/dispatcher.py
@@ -107,7 +107,7 @@ class Dispatcher:
                 futures.append(rpc.rpc_async("worker%d" % kvstore_rank, graph_services.push_tensors,
                                              args=(keys, memory_ts, 'memory_ts')))
                 futures.append(rpc.rpc_async("worker%d" % kvstore_rank, graph_services.push_tensors,
-                                             args=(keys, mailbox, 'mail')))
+                                             args=(keys, mailbox, 'mailbox')))
                 futures.append(rpc.rpc_async("worker%d" % kvstore_rank, graph_services.push_tensors,
                                              args=(keys, mailbox_ts, 'mailbox_ts')))
         if not defer_sync:

--- a/gnnflow/distributed/dispatcher.py
+++ b/gnnflow/distributed/dispatcher.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Optional
 
 import numpy as np
@@ -83,6 +84,8 @@ class Dispatcher:
                                              args=(keys, features, 'node')))
             if edge_feats is not None:
                 keys = edges[3]
+                logging.info(
+                    "keys: {}, is assigned to kvstore_rank: {}".format(keys, kvstore_rank))
                 features = edge_feats[keys]
                 futures.append(rpc.rpc_async("worker%d" % kvstore_rank, graph_services.push_tensors,
                                              args=(keys, features, 'edge')))

--- a/gnnflow/distributed/dispatcher.py
+++ b/gnnflow/distributed/dispatcher.py
@@ -33,7 +33,8 @@ class Dispatcher:
 
     def dispatch_edges(self, src_nodes: torch.Tensor, dst_nodes: torch.Tensor,
                        timestamps: torch.Tensor, eids: torch.Tensor, node_feats: Optional[torch.Tensor] = None,
-                       edge_feats: Optional[torch.Tensor] = None, defer_sync: bool = False):
+                       edge_feats: Optional[torch.Tensor] = None, defer_sync: bool = False,
+                       dim_memory: Optional[int] = 0):
         """
         Dispatch the edges to the workers.
 
@@ -45,6 +46,7 @@ class Dispatcher:
             node_feats (torch.Tensor): The node features of the edges.
             edge_feats (torch.Tensor): The edge features of the edges.
             defer_sync (bool): Whether to defer the synchronization.
+            dim_memory (int): Dimension of the memory.
         """
         self._nodes.update(src_nodes)
         self._nodes.update(dst_nodes)
@@ -54,6 +56,9 @@ class Dispatcher:
             src_nodes, dst_nodes, timestamps, eids)
 
         self._max_node = self._partitioner._max_node
+
+        dim_node = 0 if node_feats is None else node_feats.shape[1]
+        dim_edge = 0 if edge_feats is None else edge_feats.shape[1]
 
         # Dispatch the partitions to the workers.
         futures = []
@@ -87,7 +92,24 @@ class Dispatcher:
                 features = edge_feats[keys]
                 futures.append(rpc.rpc_async("worker%d" % kvstore_rank, graph_services.push_tensors,
                                              args=(keys, features, 'edge')))
-
+            if dim_memory > 0:
+                keys = torch.cat((edges[0], edges[1])).unique()
+                # use None as value and just init keys here.
+                memory = torch.zeros(
+                    (len(keys), dim_memory), dtype=torch.float32)
+                memory_ts = torch.zeros(len(keys), dtype=torch.float32)
+                dim_raw_message = 2 * dim_memory + dim_edge
+                mailbox = torch.zeros(
+                    (len(keys), dim_raw_message), dtype=torch.float32)
+                mailbox_ts = torch.zeros((len(keys), ), dtype=torch.float32)
+                futures.append(rpc.rpc_async("worker%d" % kvstore_rank, graph_services.push_tensors,
+                                             args=(keys, memory, 'memory')))
+                futures.append(rpc.rpc_async("worker%d" % kvstore_rank, graph_services.push_tensors,
+                                             args=(keys, memory_ts, 'memory_ts')))
+                futures.append(rpc.rpc_async("worker%d" % kvstore_rank, graph_services.push_tensors,
+                                             args=(keys, mailbox, 'mail')))
+                futures.append(rpc.rpc_async("worker%d" % kvstore_rank, graph_services.push_tensors,
+                                             args=(keys, mailbox_ts, 'mail_ts')))
         if not defer_sync:
             # Wait for the workers to finish.
             for future in futures:
@@ -95,15 +117,14 @@ class Dispatcher:
 
             self.broadcast_graph_metadata()
             self.broadcast_partition_table()
-            dim_node = 0 if node_feats is None else node_feats.shape[1]
-            dim_edge = 0 if edge_feats is None else edge_feats.shape[1]
             self.broadcast_node_edge_dim(dim_node, dim_edge)
 
         return futures
 
     def partition_graph(self, dataset: pd.DataFrame, ingestion_batch_size: int,
                         undirected: bool, node_feats: Optional[torch.Tensor] = None,
-                        edge_feats: Optional[torch.Tensor] = None):
+                        edge_feats: Optional[torch.Tensor] = None,
+                        dim_memory: Optional[int] = 0):
         """
         partition the dataset to the workers.
 
@@ -113,6 +134,7 @@ class Dispatcher:
             undirected (bool): Whether the graph is undirected.
             node_feats (torch.Tensor): The node features of the dataset.
             edge_feats (torch.Tensor): The edge features of the dataset.
+            dim_memory (int): Dimension of the memory.
         """
         # Partition the dataset.
         futures = []
@@ -137,7 +159,8 @@ class Dispatcher:
             eids = torch.from_numpy(eids)
 
             futures.extend(self.dispatch_edges(src_nodes, dst_nodes,
-                           timestamps, eids, node_feats, edge_feats, defer_sync=True))
+                           timestamps, eids, node_feats, edge_feats,
+                           defer_sync=True, dim_memory=dim_memory))
 
             # Wait for the workers to finish.
             for future in futures:

--- a/gnnflow/distributed/dispatcher.py
+++ b/gnnflow/distributed/dispatcher.py
@@ -9,7 +9,7 @@ import torch.distributed.rpc as rpc
 
 import gnnflow.distributed.graph_services as graph_services
 from gnnflow.distributed.partition import get_partitioner
-from gnnflow.distributed.utils import local_world_size
+from gnnflow.utils import local_world_size
 
 global dispatcher
 dispatcher = None

--- a/gnnflow/distributed/dispatcher.py
+++ b/gnnflow/distributed/dispatcher.py
@@ -109,7 +109,7 @@ class Dispatcher:
                 futures.append(rpc.rpc_async("worker%d" % kvstore_rank, graph_services.push_tensors,
                                              args=(keys, mailbox, 'mail')))
                 futures.append(rpc.rpc_async("worker%d" % kvstore_rank, graph_services.push_tensors,
-                                             args=(keys, mailbox_ts, 'mail_ts')))
+                                             args=(keys, mailbox_ts, 'mailbox_ts')))
         if not defer_sync:
             # Wait for the workers to finish.
             for future in futures:

--- a/gnnflow/distributed/dispatcher.py
+++ b/gnnflow/distributed/dispatcher.py
@@ -84,8 +84,6 @@ class Dispatcher:
                                              args=(keys, features, 'node')))
             if edge_feats is not None:
                 keys = edges[3]
-                logging.info(
-                    "keys: {}, is assigned to kvstore_rank: {}".format(keys, kvstore_rank))
                 features = edge_feats[keys]
                 futures.append(rpc.rpc_async("worker%d" % kvstore_rank, graph_services.push_tensors,
                                              args=(keys, features, 'edge')))

--- a/gnnflow/distributed/dist_context.py
+++ b/gnnflow/distributed/dist_context.py
@@ -14,7 +14,8 @@ from gnnflow.utils import load_feat
 
 def initialize(rank: int, world_size: int, dataset: pd.DataFrame,
                ingestion_batch_size: int, partition_strategy: str,
-               num_partitions: int, undirected: bool, data_name: str):
+               num_partitions: int, undirected: bool, data_name: str,
+               use_memory: int):
     """
     Initialize the distributed environment.
 
@@ -26,6 +27,7 @@ def initialize(rank: int, world_size: int, dataset: pd.DataFrame,
         num_partitions (int): The number of partitions to split the dataset into.
         undirected (bool): Whether the graph is undirected.
         data_name (str): the dataset name of the dataset for loading features.
+        use_memory (bool): if the kvstore need to initialize the memory.
     """
     rpc.init_rpc("worker%d" % rank, rank=rank, world_size=world_size)
     logging.info("Rank %d: Initialized RPC.", rank)
@@ -41,7 +43,8 @@ def initialize(rank: int, world_size: int, dataset: pd.DataFrame,
         # load the feature only at rank 0
         node_feats, edge_feats = load_feat(data_name)
         dispatcher.partition_graph(dataset, ingestion_batch_size,
-                                   undirected, node_feats, edge_feats)
+                                   undirected, node_feats, edge_feats,
+                                   use_memory)
 
     # check
     torch.distributed.barrier()

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -15,7 +15,7 @@ import gnnflow.distributed.graph_services as graph_services
 from gnnflow import TemporalSampler
 from gnnflow.distributed.common import SamplingResultTorch
 from gnnflow.distributed.dist_graph import DistributedDynamicGraph
-from gnnflow.distributed.utils import local_rank, local_world_size
+from gnnflow.utils import local_rank, local_world_size
 from libgnnflow import SamplingResult
 
 
@@ -136,6 +136,7 @@ class DistributedTemporalSampler:
                 timestamps[partition_mask]).contiguous()
 
             worker_rank = partition_id * self._local_world_size + self._local_rank
+            logging.debug("call remote sample_layer_local on worker %d", worker_rank)
             if worker_rank == self._rank:
                 futures.append(graph_services.sample_layer_local(partition_vertices, partition_timestamps,
                                                                  layer, snapshot))

--- a/gnnflow/distributed/graph_services.py
+++ b/gnnflow/distributed/graph_services.py
@@ -266,6 +266,21 @@ def pull_tensors(keys: torch.Tensor, mode: str) -> List[torch.Tensor]:
     return kvstore_server.pull(keys, mode)
 
 
+def pull_maps(keys: torch.Tensor, mode: str) -> List[torch.Tensor]:
+    """
+    Pull tensors from the remote workers for KVStore servers.
+
+    Args:
+        keys (torch.Tensor): The key of the tensors.
+        mode (str): The mode of the pull operation.
+
+    Returns:
+        List[torch.Tensor]: The pulled tensors.
+    """
+    kvstore_server = get_kvstore_server()
+    return kvstore_server._edge_feat_map
+
+
 def set_dim_node(dim_node: int):
     """
     Set the dim node.

--- a/gnnflow/distributed/graph_services.py
+++ b/gnnflow/distributed/graph_services.py
@@ -266,21 +266,6 @@ def pull_tensors(keys: torch.Tensor, mode: str) -> List[torch.Tensor]:
     return kvstore_server.pull(keys, mode)
 
 
-def pull_maps(keys: torch.Tensor, mode: str) -> List[torch.Tensor]:
-    """
-    Pull tensors from the remote workers for KVStore servers.
-
-    Args:
-        keys (torch.Tensor): The key of the tensors.
-        mode (str): The mode of the pull operation.
-
-    Returns:
-        List[torch.Tensor]: The pulled tensors.
-    """
-    kvstore_server = get_kvstore_server()
-    return kvstore_server._edge_feat_map
-
-
 def set_dim_node(dim_node: int):
     """
     Set the dim node.

--- a/gnnflow/distributed/graph_services.py
+++ b/gnnflow/distributed/graph_services.py
@@ -266,6 +266,14 @@ def pull_tensors(keys: torch.Tensor, mode: str) -> List[torch.Tensor]:
     return kvstore_server.pull(keys, mode)
 
 
+def reset_memory():
+    """
+    Reset all the values in the memory & mailbox.
+    """
+    kvstore_server = get_kvstore_server()
+    kvstore_server.reset_memory()
+
+
 def set_dim_node(dim_node: int):
     """
     Set the dim node.

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -76,8 +76,8 @@ class KVStoreServer:
             return torch.stack([self._node_feat_map[int(key)] for key in keys])
         elif mode == 'edge':
             for key in keys:
-                logging.info("type edge: {}").format(
-                    self._edge_feat_map[int(key)])
+                logging.info("type edge: {}".format(
+                    self._edge_feat_map[int(key)]))
             return [self._edge_feat_map[int(key)] for key in keys]
         elif mode == 'memory':
             return torch.stack([self._memory_map[int(key)] for key in keys])

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -129,7 +129,7 @@ class KVStoreClient:
                 use nid to get the partition ids
 
         """
-        logging.info("tensors: {}".format(tensors))
+        # logging.info("tensors: {}".format(tensors))
         logging.info("tensors type: {}".format(type(tensors)))
         # dispatch different keys to different partitions
         partition_table = self._partition_table

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List, Optional
 
 import torch
@@ -60,6 +61,8 @@ class KVStoreServer:
         if mode == 'node':
             return [self._node_feat_map[key] for key in keys]
         elif mode == 'edge':
+            logging.info("edge_feat_map: {}".format(
+                self._edge_feat_map.keys()))
             return [self._edge_feat_map[key] for key in keys]
         elif mode == 'memory':
             return [self._memory_map[key] for key in keys]

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -187,7 +187,7 @@ class KVStoreClient:
             all_pull_results += len(pull_result)
 
         all_pull_results = torch.zeros(
-            (all_pull_results, pull_result[0].shape[1]), dtype=torch.float32)
+            (all_pull_results, pull_results[0].shape[1]), dtype=torch.float32)
 
         for mask, pull_result in (masks, pull_results):
             idx = mask.nonzero().squeeze()

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -37,7 +37,7 @@ class KVStoreServer:
             tensors (List[torch.Tensor]): The tensors.
         """
         logging.info("keys: {}".format(keys.shape))
-        logging.info("keys: {}".format(keys.shape))
+        logging.info("tensors: {}".format(tensors.shape))
         assert len(keys) == len(
             tensors), "The number of keys {} and tensors {} must be the same.".format(
             len(keys), len(tensors))
@@ -148,7 +148,7 @@ class KVStoreClient:
             worker_rank = partition_id * self._num_workers_per_machine
 
             futures.append(rpc.rpc_async('worker{}'.format(worker_rank),
-                                         graph_services.push_tensors, args=(partition_keys, tensors, mode)))
+                                         graph_services.push_tensors, args=(partition_keys, partition_tensors, mode)))
 
         for future in futures:
             future.wait()

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -77,7 +77,7 @@ class KVStoreServer:
         elif mode == 'edge':
             for key in keys:
                 logging.info("type edge: {}".format(
-                    self._edge_feat_map[int(key)]))
+                    type(self._edge_feat_map[int(key)])))
             return [self._edge_feat_map[int(key)] for key in keys]
         elif mode == 'memory':
             return torch.stack([self._memory_map[int(key)] for key in keys])
@@ -230,7 +230,7 @@ class KVStoreClient:
             all_pull_results = torch.zeros(
                 (all_pull_results, pull_results[0][0].shape[0]), dtype=torch.float32)
 
-        logging.info("pull_request types: {}".format(pull_results))
+        # logging.info("pull_request types: {}".format(pull_results))
         logging.info("pull_request types: {}".format(type(pull_results)))
         for mask, pull_result in zip(masks, pull_results):
             idx = mask.nonzero().squeeze()

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -77,7 +77,8 @@ class KVStoreServer:
         elif mode == 'memory':
             return [self._memory_map[int(key)] for key in keys]
         elif mode == 'memory_ts':
-            return [self._memory_ts_map[int(key)] for key in keys]
+            memory_ts = [self._memory_ts_map[int(key)] for key in keys]
+            logging.info("memory_ts: {}".format(memory_ts))
         elif mode == 'mailbox':
             return [self._mailbox_map[int(key)] for key in keys]
         elif mode == 'mailbox_ts':
@@ -215,11 +216,13 @@ class KVStoreClient:
         for pull_result in pull_results:
             all_pull_results += len(pull_result)
 
-        logging.info("pull_results {}".format(pull_results))
-        logging.info("pull_results {}".format(pull_results[0][0].shape))
-        logging.info("pull_results {}".format(pull_results[0][0].shape))
-        all_pull_results = torch.zeros(
-            (all_pull_results, pull_results[0][0].shape[0]), dtype=torch.float32)
+        # torch scalar
+        if pull_results[0][0].shape == torch.Size([]):
+            all_pull_results = torch.zeros(
+                (all_pull_results,), dtype=torch.float32)
+        else:
+            all_pull_results = torch.zeros(
+                (all_pull_results, pull_results[0][0].shape[0]), dtype=torch.float32)
 
         for mask, pull_result in zip(masks, pull_results):
             idx = mask.nonzero().squeeze()

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -39,7 +39,8 @@ class KVStoreServer:
         assert len(keys) == len(
             tensors), "The number of keys {} and tensors {} must be the same.".format(
             len(keys), len(tensors))
-
+        logging.info("tensors: {}".format(tensors))
+        logging.info("tensors type: {}".format(type(tensors)))
         if mode == 'node':
             for key, tensor in zip(keys, tensors):
                 self._node_feat_map[int(key)] = tensor
@@ -74,7 +75,7 @@ class KVStoreServer:
         if mode == 'node':
             return torch.stack([self._node_feat_map[int(key)] for key in keys])
         elif mode == 'edge':
-            return torch.stack([self._edge_feat_map[int(key)] for key in keys])
+            return [self._edge_feat_map[int(key)] for key in keys]
         elif mode == 'memory':
             return torch.stack([self._memory_map[int(key)] for key in keys])
         elif mode == 'memory_ts':

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -36,8 +36,6 @@ class KVStoreServer:
             keys (torch.Tensor): The keys.
             tensors (List[torch.Tensor]): The tensors.
         """
-        logging.info("keys: {}".format(keys.shape))
-        logging.info("tensors: {}".format(tensors.shape))
         assert len(keys) == len(
             tensors), "The number of keys {} and tensors {} must be the same.".format(
             len(keys), len(tensors))

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -189,7 +189,7 @@ class KVStoreClient:
         all_pull_results = torch.zeros(
             (all_pull_results, pull_results[0][0].shape[0]), dtype=torch.float32)
 
-        for mask, pull_result in (masks, pull_results):
+        for mask, pull_result in zip(masks, pull_results):
             idx = mask.nonzero().squeeze()
             all_pull_results[idx] = pull_result
 

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -191,6 +191,6 @@ class KVStoreClient:
 
         for mask, pull_result in zip(masks, pull_results):
             idx = mask.nonzero().squeeze()
-            all_pull_results[idx] = pull_result
+            all_pull_results[idx] = torch.tensor(pull_result)
 
         return all_pull_results

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -36,8 +36,11 @@ class KVStoreServer:
             keys (torch.Tensor): The keys.
             tensors (List[torch.Tensor]): The tensors.
         """
+        logging.info("keys: {}".format(keys.shape))
+        logging.info("keys: {}".format(keys.shape))
         assert len(keys) == len(
-            tensors), "The number of keys and tensors must be the same."
+            tensors), "The number of keys {} and tensors {} must be the same.".format(
+            len(keys), len(tensors))
 
         if mode == 'node':
             for key, tensor in zip(keys, tensors):

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -61,6 +61,8 @@ class KVStoreServer:
         if mode == 'node':
             return [self._node_feat_map[key] for key in keys]
         elif mode == 'edge':
+            logging.debug("edge_feat_map: {}".format(
+                self._edge_feat_map.keys()))
             return [self._edge_feat_map[key] for key in keys]
         elif mode == 'memory':
             return [self._memory_map[key] for key in keys]

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -191,8 +191,8 @@ class KVStoreClient:
 
         for mask, pull_result in zip(masks, pull_results):
             idx = mask.nonzero().squeeze()
-            logging.info("idx: {}".format(idx))
-            logging.info("pull_result: {}".format(pull_result))
-            all_pull_results[idx] = torch.tensor(pull_result)
+            # logging.info("idx: {}".format(idx))
+            # logging.info("pull_result: {}".format(pull_result))
+            all_pull_results[idx] = torch.stack(pull_result)
 
         return all_pull_results

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -1,4 +1,3 @@
-import logging
 from typing import List, Optional
 
 import torch
@@ -39,8 +38,7 @@ class KVStoreServer:
         assert len(keys) == len(
             tensors), "The number of keys {} and tensors {} must be the same.".format(
             len(keys), len(tensors))
-        # logging.info("tensors: {}".format(tensors))
-        logging.info("tensors type: {}".format(type(tensors)))
+
         if mode == 'node':
             for key, tensor in zip(keys, tensors):
                 self._node_feat_map[int(key)] = tensor
@@ -225,8 +223,6 @@ class KVStoreClient:
             all_pull_results = torch.zeros(
                 (all_pull_results, pull_results[0][0].shape[0]), dtype=torch.float32)
 
-        # logging.info("pull_request types: {}".format(pull_results))
-        logging.info("pull_request types: {}".format(type(pull_result)))
         for mask, pull_result in zip(masks, pull_results):
             idx = mask.nonzero().squeeze()
             all_pull_results[idx] = pull_result

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -186,6 +186,7 @@ class KVStoreClient:
         for pull_result in pull_results:
             all_pull_results += len(pull_result)
 
+        logging.info("pull results: {}".format(pull_results))
         all_pull_results = torch.zeros(
             (all_pull_results, pull_results[0].shape[1]), dtype=torch.float32)
 

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -38,13 +38,13 @@ class KVStoreServer:
 
         if mode == 'node':
             for key, tensor in zip(keys, tensors):
-                self._node_feat_map[key] = tensor
+                self._node_feat_map[int(key)] = tensor
         elif mode == 'edge':
             for key, tensor in zip(keys, tensors):
-                self._edge_feat_map[key] = tensor
+                self._edge_feat_map[int(key)] = tensor
         elif mode == 'memory':
             for key, tensor in zip(keys, tensors):
-                self._memory_map[key] = tensor
+                self._memory_map[int(key)] = tensor
         else:
             raise ValueError(f"Unknown mode: {mode}")
 
@@ -59,13 +59,11 @@ class KVStoreServer:
             List[torch.Tensor]: The tensors.
         """
         if mode == 'node':
-            return [self._node_feat_map[key] for key in keys]
+            return [self._node_feat_map[int(key)] for key in keys]
         elif mode == 'edge':
-            logging.debug("edge_feat_map: {}".format(
-                self._edge_feat_map.keys()))
-            return [self._edge_feat_map[key] for key in keys]
+            return [self._edge_feat_map[int(key)] for key in keys]
         elif mode == 'memory':
-            return [self._memory_map[key] for key in keys]
+            return [self._memory_map[int(key)] for key in keys]
         else:
             raise ValueError(f"Unknown mode: {mode}")
 

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -215,6 +215,9 @@ class KVStoreClient:
         for pull_result in pull_results:
             all_pull_results += len(pull_result)
 
+        logging.info("pull_results {}".format(pull_results))
+        logging.info("pull_results {}".format(pull_results[0][0].shape))
+        logging.info("pull_results {}".format(pull_results[0][0].shape))
         all_pull_results = torch.zeros(
             (all_pull_results, pull_results[0][0].shape[0]), dtype=torch.float32)
 

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -186,7 +186,7 @@ class KVStoreClient:
         for pull_result in pull_results:
             all_pull_results += len(pull_result)
 
-        # logging.info("pull results: {}".format(pull_results))
+        logging.info("pull results: {}".format(pull_results[0][0]))
         all_pull_results = torch.zeros(
             (all_pull_results, pull_results[0][0].shape[1]), dtype=torch.float32)
 

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -156,9 +156,6 @@ class KVStoreClient:
 
             # local rank 0 in those partitions
             worker_rank = partition_id * self._num_workers_per_machine
-            logging.info("num_partitions: {}".format(self._num_partitions))
-            logging.info("_num_workers_per_machine: {}".format(
-                self._num_workers_per_machine))
             futures.append(rpc.rpc_async('worker{}'.format(worker_rank),
                                          graph_services.pull_tensors, args=(partition_keys, mode)))
             masks.append(partition_mask)

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -28,7 +28,7 @@ class KVStoreServer:
         self._mailbox_map = {}
         self._mailbox_ts_map = {}
 
-    def push(self, keys: torch.Tensor, tensors: List[torch.Tensor], mode: str):
+    def push(self, keys: torch.Tensor, tensors: torch.Tensor, mode: str):
         """
         Push tensors to the server.
 
@@ -72,17 +72,17 @@ class KVStoreServer:
             List[torch.Tensor]: The tensors.
         """
         if mode == 'node':
-            return [self._node_feat_map[int(key)] for key in keys]
+            return torch.stack([self._node_feat_map[int(key)] for key in keys])
         elif mode == 'edge':
-            return [self._edge_feat_map[int(key)] for key in keys]
+            return torch.stack([self._edge_feat_map[int(key)] for key in keys])
         elif mode == 'memory':
-            return [self._memory_map[int(key)] for key in keys]
+            return torch.stack([self._memory_map[int(key)] for key in keys])
         elif mode == 'memory_ts':
-            return [self._memory_ts_map[int(key)] for key in keys]
+            return torch.stack([self._memory_ts_map[int(key)] for key in keys])
         elif mode == 'mailbox':
-            return [self._mailbox_map[int(key)] for key in keys]
+            return torch.stack([self._mailbox_map[int(key)] for key in keys])
         elif mode == 'mailbox_ts':
-            return [self._mailbox_ts_map[int(key)] for key in keys]
+            return torch.stack([self._mailbox_ts_map[int(key)] for key in keys])
         else:
             raise ValueError(f"Unknown mode: {mode}")
 
@@ -226,7 +226,7 @@ class KVStoreClient:
 
         for mask, pull_result in zip(masks, pull_results):
             idx = mask.nonzero().squeeze()
-            all_pull_results[idx] = torch.stack(pull_result)
+            all_pull_results[idx] = pull_results
 
         return all_pull_results
 

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -186,9 +186,9 @@ class KVStoreClient:
         for pull_result in pull_results:
             all_pull_results += len(pull_result)
 
-        logging.info("pull results: {}".format(pull_results))
+        # logging.info("pull results: {}".format(pull_results))
         all_pull_results = torch.zeros(
-            (all_pull_results, pull_results[0].shape[1]), dtype=torch.float32)
+            (all_pull_results, pull_results[0][0].shape[1]), dtype=torch.float32)
 
         for mask, pull_result in (masks, pull_results):
             idx = mask.nonzero().squeeze()

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -191,6 +191,8 @@ class KVStoreClient:
 
         for mask, pull_result in zip(masks, pull_results):
             idx = mask.nonzero().squeeze()
+            logging.info("idx: {}".format(idx))
+            logging.info("pull_result: {}".format(pull_result))
             all_pull_results[idx] = torch.tensor(pull_result)
 
         return all_pull_results

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -61,8 +61,6 @@ class KVStoreServer:
         if mode == 'node':
             return [self._node_feat_map[key] for key in keys]
         elif mode == 'edge':
-            logging.info("edge_feat_map: {}".format(
-                self._edge_feat_map.keys()))
             return [self._edge_feat_map[key] for key in keys]
         elif mode == 'memory':
             return [self._memory_map[key] for key in keys]
@@ -157,6 +155,10 @@ class KVStoreClient:
 
             # local rank 0 in those partitions
             worker_rank = partition_id * self._num_workers_per_machine
+
+            _edge_map = rpc.rpc_sync('worker{}'.format(worker_rank),
+                                     graph_services.pull_tensors, args=(partition_keys, mode))
+            logging.info("edge_map: {}".format(_edge_map.keys()))
 
             futures.append(rpc.rpc_async('worker{}'.format(worker_rank),
                                          graph_services.pull_tensors, args=(partition_keys, mode)))

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -62,7 +62,7 @@ class KVStoreServer:
         else:
             raise ValueError(f"Unknown mode: {mode}")
 
-    def pull(self, keys: torch.Tensor, mode: str) -> List[torch.Tensor]:
+    def pull(self, keys: torch.Tensor, mode: str) -> torch.Tensor:
         """
         Pull tensors from the server.
 
@@ -114,7 +114,7 @@ class KVStoreClient:
         self._num_workers_per_machine = num_workers_per_machine
         self._local_rank = local_rank
 
-    def push(self, keys: torch.Tensor, tensors: List[torch.Tensor], mode: str, nid: Optional[torch.Tensor] = None):
+    def push(self, keys: torch.Tensor, tensors: torch.Tensor, mode: str, nid: Optional[torch.Tensor] = None):
         """
         Push tensors to the corresponding KVStore servers according to the partition table.
 
@@ -126,8 +126,6 @@ class KVStoreClient:
                 use nid to get the partition ids
 
         """
-        # logging.info("tensors: {}".format(tensors))
-        logging.info("tensors type: {}".format(type(tensors)))
         # dispatch different keys to different partitions
         partition_table = self._partition_table
         if mode == 'edge':

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -143,7 +143,7 @@ class KVStoreClient:
             if partition_mask.sum() == 0:
                 continue
             partition_keys = keys[partition_mask]
-
+            partition_tensors = tensors[partition_mask]
             # local rank 0 in those partitions
             worker_rank = partition_id * self._num_workers_per_machine
 

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -75,10 +75,7 @@ class KVStoreServer:
         if mode == 'node':
             return torch.stack([self._node_feat_map[int(key)] for key in keys])
         elif mode == 'edge':
-            for key in keys:
-                logging.info("type edge: {}".format(
-                    type(self._edge_feat_map[int(key)])))
-            return [self._edge_feat_map[int(key)] for key in keys]
+            return torch.stack([self._edge_feat_map[int(key)] for key in keys])
         elif mode == 'memory':
             return torch.stack([self._memory_map[int(key)] for key in keys])
         elif mode == 'memory_ts':
@@ -231,10 +228,10 @@ class KVStoreClient:
                 (all_pull_results, pull_results[0][0].shape[0]), dtype=torch.float32)
 
         # logging.info("pull_request types: {}".format(pull_results))
-        logging.info("pull_request types: {}".format(type(pull_results)))
+        logging.info("pull_request types: {}".format(type(pull_result)))
         for mask, pull_result in zip(masks, pull_results):
             idx = mask.nonzero().squeeze()
-            all_pull_results[idx] = pull_results
+            all_pull_results[idx] = pull_result
 
         return all_pull_results
 

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List, Optional
 
 import torch
@@ -124,6 +125,8 @@ class KVStoreClient:
                 use nid to get the partition ids
 
         """
+        logging.info("tensors: {}".format(tensors))
+        logging.info("tensors type: {}".format(type(tensors)))
         # dispatch different keys to different partitions
         partition_table = self._partition_table
         if mode == 'edge':
@@ -223,6 +226,8 @@ class KVStoreClient:
             all_pull_results = torch.zeros(
                 (all_pull_results, pull_results[0][0].shape[0]), dtype=torch.float32)
 
+        logging.info("pull_request types: {}".format(pull_results))
+        logging.info("pull_request types: {}".format(type(pull_results)))
         for mask, pull_result in zip(masks, pull_results):
             idx = mask.nonzero().squeeze()
             all_pull_results[idx] = pull_results

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -156,10 +156,6 @@ class KVStoreClient:
             # local rank 0 in those partitions
             worker_rank = partition_id * self._num_workers_per_machine
 
-            _edge_map = rpc.rpc_sync('worker{}'.format(worker_rank),
-                                     graph_services.pull_maps, args=(partition_keys, mode))
-            logging.info("edge_map: {}".format(_edge_map.keys()))
-
             futures.append(rpc.rpc_async('worker{}'.format(worker_rank),
                                          graph_services.pull_tensors, args=(partition_keys, mode)))
 

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -186,9 +186,8 @@ class KVStoreClient:
         for pull_result in pull_results:
             all_pull_results += len(pull_result)
 
-        logging.info("pull results: {}".format(pull_results[0][0]))
         all_pull_results = torch.zeros(
-            (all_pull_results, pull_results[0][0].shape[1]), dtype=torch.float32)
+            (all_pull_results, pull_results[0][0].shape[0]), dtype=torch.float32)
 
         for mask, pull_result in (masks, pull_results):
             idx = mask.nonzero().squeeze()

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -77,8 +77,7 @@ class KVStoreServer:
         elif mode == 'memory':
             return [self._memory_map[int(key)] for key in keys]
         elif mode == 'memory_ts':
-            memory_ts = [self._memory_ts_map[int(key)] for key in keys]
-            logging.info("memory_ts: {}".format(memory_ts))
+            return [self._memory_ts_map[int(key)] for key in keys]
         elif mode == 'mailbox':
             return [self._mailbox_map[int(key)] for key in keys]
         elif mode == 'mailbox_ts':

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -156,7 +156,9 @@ class KVStoreClient:
 
             # local rank 0 in those partitions
             worker_rank = partition_id * self._num_workers_per_machine
-
+            logging.info("num_partitions: {}".format(self._num_partitions))
+            logging.info("_num_workers_per_machine: {}".format(
+                self._num_workers_per_machine))
             futures.append(rpc.rpc_async('worker{}'.format(worker_rank),
                                          graph_services.pull_tensors, args=(partition_keys, mode)))
             masks.append(partition_mask)
@@ -191,8 +193,6 @@ class KVStoreClient:
 
         for mask, pull_result in zip(masks, pull_results):
             idx = mask.nonzero().squeeze()
-            # logging.info("idx: {}".format(idx))
-            # logging.info("pull_result: {}".format(pull_result))
             all_pull_results[idx] = torch.stack(pull_result)
 
         return all_pull_results

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -39,7 +39,7 @@ class KVStoreServer:
         assert len(keys) == len(
             tensors), "The number of keys {} and tensors {} must be the same.".format(
             len(keys), len(tensors))
-        logging.info("tensors: {}".format(tensors))
+        # logging.info("tensors: {}".format(tensors))
         logging.info("tensors type: {}".format(type(tensors)))
         if mode == 'node':
             for key, tensor in zip(keys, tensors):
@@ -75,6 +75,9 @@ class KVStoreServer:
         if mode == 'node':
             return torch.stack([self._node_feat_map[int(key)] for key in keys])
         elif mode == 'edge':
+            for key in keys:
+                logging.info("type edge: {}").format(
+                    self._edge_feat_map[int(key)])
             return [self._edge_feat_map[int(key)] for key in keys]
         elif mode == 'memory':
             return torch.stack([self._memory_map[int(key)] for key in keys])

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -157,7 +157,7 @@ class KVStoreClient:
             worker_rank = partition_id * self._num_workers_per_machine
 
             _edge_map = rpc.rpc_sync('worker{}'.format(worker_rank),
-                                     graph_services.pull_tensors, args=(partition_keys, mode))
+                                     graph_services.pull_maps, args=(partition_keys, mode))
             logging.info("edge_map: {}".format(_edge_map.keys()))
 
             futures.append(rpc.rpc_async('worker{}'.format(worker_rank),

--- a/gnnflow/distributed/partition.py
+++ b/gnnflow/distributed/partition.py
@@ -39,7 +39,6 @@ class Partitioner:
         self._max_node = 0
         # NID -> partition ID, maximum 128 partitions
         self._partition_table = torch.empty(self._max_node, dtype=torch.int8)
-        self._partition_table[:] = self.UNASSIGNED
 
 
     def get_num_partitions(self) -> int:
@@ -70,7 +69,10 @@ class Partitioner:
 
         if max_node > self._max_node:
             self._partition_table.resize_(max_node + 1)
-            self._partition_table[self._max_node + 1:] = self.UNASSIGNED
+            if self._max_node == 0:
+                self._partition_table[:] = self.UNASSIGNED
+            else:
+                self._partition_table[self._max_node + 1:] = self.UNASSIGNED
             self._max_node = max_node
         # dispatch edges to already assigned source nodes
         partitions = []
@@ -305,7 +307,10 @@ class LDGPartitioner(Partitioner):
         max_node = int(torch.max(torch.max(src_nodes), torch.max(dst_nodes)))
         if max_node > self._max_node:
             self._partition_table.resize_(max_node + 1)
-            self._partition_table[self._max_node + 1:] = self.UNASSIGNED
+            if self._max_node == 0:
+                self._partition_table[:] = self.UNASSIGNED
+            else:
+                self._partition_table[self._max_node + 1:] = self.UNASSIGNED
             self._max_node = max_node
 
         # update edges partitioned

--- a/gnnflow/distributed/utils.py
+++ b/gnnflow/distributed/utils.py
@@ -1,22 +1,6 @@
-import os
 from collections import defaultdict
 from enum import Enum
 from threading import Lock
-
-import torch
-import torch.distributed
-
-
-def local_world_size():
-    return int(os.environ["LOCAL_WORLD_SIZE"])
-
-
-def local_rank():
-    return int(os.environ["LOCAL_RANK"])
-
-
-def rank():
-    return torch.distributed.get_rank()
 
 
 class WorkStatus(Enum):

--- a/gnnflow/models/dgnn.py
+++ b/gnnflow/models/dgnn.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional, Union
 
 import torch
 from dgl.heterograph import DGLBlock
+from gnnflow.distributed.kvstore import KVStoreClient
 from gnnflow.models.modules.layers import EdgePredictor, TransfomerAttentionLayer
 from gnnflow.models.modules.memory import Memory
 from gnnflow.models.modules.memory_updater import GRUMemeoryUpdater
@@ -24,7 +25,9 @@ class DGNN(torch.nn.Module):
                  use_memory: bool, dim_memory: Optional[int] = None,
                  num_nodes: Optional[int] = None,
                  memory_device: Union[torch.device, str] = 'cpu',
-                 memory_shared: bool = False, *args, **kwargs):
+                 memory_shared: bool = False,
+                 kvstore_client: Optional[KVStoreClient] = None,
+                 *args, **kwargs):
         """
         Args:
             dim_node: dimension of node features/embeddings
@@ -41,6 +44,7 @@ class DGNN(torch.nn.Module):
             num_nodes: number of nodes in the graph
             memory_device: device of the memory
             memory_shared: whether to share memory across local workers
+            kvstore_client: The KVStore_Client for fetching memorys when using partition
         """
         super(DGNN, self).__init__()
         self.dim_node = dim_node
@@ -61,7 +65,8 @@ class DGNN(torch.nn.Module):
             assert num_nodes is not None, 'num_nodes is required when using memory'
 
             self.memory = Memory(num_nodes, dim_edge, dim_memory,
-                                 memory_device, memory_shared)
+                                 memory_device, memory_shared,
+                                 kvstore_client)
 
             self.memory_updater = GRUMemeoryUpdater(
                 dim_node, dim_edge, dim_time, dim_memory)

--- a/gnnflow/models/modules/memory.py
+++ b/gnnflow/models/modules/memory.py
@@ -4,16 +4,15 @@ This code is based on the implementation of TGL's memory module.
 Implementation at:
     https://github.com/amazon-research/tgl/blob/main/memorys.py
 """
-import logging
 from typing import Dict, Optional, Union
 
 import torch
 import torch.distributed
 from dgl.heterograph import DGLBlock
-
 from dgl.utils.shared_mem import create_shared_mem_array, get_shared_mem_array
 
 from gnnflow.distributed.kvstore import KVStoreClient
+from gnnflow.utils import local_rank, local_world_size
 
 
 class Memory:
@@ -51,8 +50,8 @@ class Memory:
         # if not partition, not need to use kvstore_client
         if not self.partition:
             if shared_memory:
-                local_world_size = torch.cuda.device_count()
-                local_rank = torch.distributed.get_rank() % local_world_size
+                local_world_size = local_world_size()
+                local_rank = local_rank()
             else:
                 local_world_size = 1
                 local_rank = 0

--- a/gnnflow/models/modules/memory.py
+++ b/gnnflow/models/modules/memory.py
@@ -197,12 +197,6 @@ class Memory:
             last_updated_ts: new timestamp of the nodes
         """
         if self.partition:
-            logging.info("last_updated_nid: {}".format(
-                last_updated_nid.device))
-            logging.info("last_updated_memory: {}".format(
-                last_updated_memory.device))
-            logging.info("last_updated_ts: {}".format(
-                last_updated_ts.device))
             self.kvstore_client.push(
                 last_updated_nid.cpu(), last_updated_memory.cpu(), mode='memory')
             self.kvstore_client.push(
@@ -263,8 +257,6 @@ class Memory:
 
         # update mailbox
         if self.partition:
-            logging.info("nid: {}".format(nid.device))
-            logging.info("mail: {}".format(mail.device))
             self.kvstore_client.push(nid, mail, mode='mailbox')
             self.kvstore_client.push(nid, mail_ts, mode='mailbox_ts')
         else:

--- a/gnnflow/models/modules/memory.py
+++ b/gnnflow/models/modules/memory.py
@@ -197,10 +197,16 @@ class Memory:
             last_updated_ts: new timestamp of the nodes
         """
         if self.partition:
+            logging.info("last_updated_nid: {}".format(
+                last_updated_nid.device))
+            logging.info("last_updated_memory: {}".format(
+                last_updated_memory.device))
+            logging.info("last_updated_ts: {}".format(
+                last_updated_ts.device))
             self.kvstore_client.push(
-                last_updated_nid, last_updated_memory, mode='memory')
+                last_updated_nid.cpu(), last_updated_memory.cpu(), mode='memory')
             self.kvstore_client.push(
-                last_updated_nid, last_updated_ts, mode='memory_ts')
+                last_updated_nid.cpu(), last_updated_ts.cpu(), mode='memory_ts')
         else:
             last_updated_nid = last_updated_nid.to(self.device)
             last_updated_memory = last_updated_memory.to(self.device)
@@ -257,8 +263,8 @@ class Memory:
 
         # update mailbox
         if self.partition:
-            logging.info("nid: {}".format(nid.shape))
-            logging.info("mail: {}".format(mail.shape))
+            logging.info("nid: {}".format(nid.device))
+            logging.info("mail: {}".format(mail.device))
             self.kvstore_client.push(nid, mail, mode='mailbox')
             self.kvstore_client.push(nid, mail_ts, mode='mailbox_ts')
         else:

--- a/gnnflow/models/modules/memory.py
+++ b/gnnflow/models/modules/memory.py
@@ -166,8 +166,6 @@ class Memory:
                 `b.srcdata['ts']` is the time stamps of all nodes.
         """
         device = b.device
-        num_dst_nodes = b.num_dst_nodes()
-        target_nodes = b.srcdata['ID'][:num_dst_nodes]
         all_nodes = b.srcdata['ID']
         assert isinstance(all_nodes, torch.Tensor)
 
@@ -182,9 +180,9 @@ class Memory:
                 all_nodes.cpu(), mode='mailbox').to(device)
         else:
             b.srcdata['mem'] = self.node_memory[all_nodes].to(device)
-            b.dstdata['mem_ts'] = self.node_memory_ts[target_nodes].to(device)
-            b.dstdata['mail_ts'] = self.mailbox_ts[target_nodes].to(device)
-            b.dstdata['mem_input'] = self.mailbox[target_nodes].to(device)
+            b.srcdata['mem_ts'] = self.node_memory_ts[all_nodes].to(device)
+            b.srcdata['mail_ts'] = self.mailbox_ts[all_nodes].to(device)
+            b.srcdata['mem_input'] = self.mailbox[all_nodes].to(device)
 
     def update_memory(self, last_updated_nid: torch.Tensor,
                       last_updated_memory: torch.Tensor,

--- a/gnnflow/models/modules/memory.py
+++ b/gnnflow/models/modules/memory.py
@@ -4,6 +4,7 @@ This code is based on the implementation of TGL's memory module.
 Implementation at:
     https://github.com/amazon-research/tgl/blob/main/memorys.py
 """
+import logging
 from typing import Dict, Optional, Union
 
 import torch
@@ -256,6 +257,8 @@ class Memory:
 
         # update mailbox
         if self.partition:
+            logging.info("nid: {}".format(nid.shape))
+            logging.info("mail: {}".format(mail.shape))
             self.kvstore_client.push(nid, mail, mode='mailbox')
             self.kvstore_client.push(nid, mail_ts, mode='mailbox_ts')
         else:

--- a/gnnflow/models/modules/memory.py
+++ b/gnnflow/models/modules/memory.py
@@ -12,6 +12,8 @@ from dgl.heterograph import DGLBlock
 
 from dgl.utils.shared_mem import create_shared_mem_array, get_shared_mem_array
 
+from gnnflow.distributed.kvstore import KVStoreClient
+
 
 class Memory:
     """
@@ -20,7 +22,8 @@ class Memory:
 
     def __init__(self, num_nodes: int, dim_edge: int, dim_memory: int,
                  device: Union[torch.device, str] = 'cpu',
-                 shared_memory: bool = False):
+                 shared_memory: bool = False,
+                 kvstore_client: Optional[KVStoreClient] = None):
         """
         Args:
             num_nodes: number of nodes in the graph
@@ -29,6 +32,7 @@ class Memory:
             dim_memory: dimension of the output of the memory
             device: device to store the memory
             shared_memory: whether to store in shared memory (for multi-GPU training)
+            kvstore_client: The KVStore_Client for fetching memorys when using partition
         """
         if shared_memory:
             device = 'cpu'
@@ -40,62 +44,70 @@ class Memory:
         self.dim_raw_message = 2 * dim_memory + dim_edge
         self.device = device
 
-        if shared_memory:
-            local_world_size = torch.cuda.device_count()
-            local_rank = torch.distributed.get_rank() % local_world_size
-        else:
-            local_world_size = 1
-            local_rank = 0
+        self.kvstore_client = kvstore_client
+        self.partition = self.kvstore_client != None
 
-        if not shared_memory:
-            self.node_memory = torch.zeros(
-                (num_nodes, dim_memory), dtype=torch.float32, device=device)
-            self.node_memory_ts = torch.zeros(
-                num_nodes, dtype=torch.float32, device=device)
-            self.mailbox = torch.zeros(
-                (num_nodes, self.dim_raw_message),
-                dtype=torch.float32, device=device)
-            self.mailbox_ts = torch.zeros(
-                (num_nodes,), dtype=torch.float32, device=device)
-        else:
-            if local_rank == 0:
-                self.node_memory = create_shared_mem_array(
-                    'node_memory', (num_nodes, dim_memory), dtype=torch.float32)
-                self.node_memory_ts = create_shared_mem_array(
-                    'node_memory_ts', (num_nodes,), dtype=torch.float32)
-                self.mailbox = create_shared_mem_array(
-                    'mailbox', (num_nodes, self.dim_raw_message),
-                    dtype=torch.float32)
-                self.mailbox_ts = create_shared_mem_array(
-                    'mailbox_ts', (num_nodes,), dtype=torch.float32)
+        # if not partition, not need to use kvstore_client
+        if not self.partition:
+            if shared_memory:
+                local_world_size = torch.cuda.device_count()
+                local_rank = torch.distributed.get_rank() % local_world_size
+            else:
+                local_world_size = 1
+                local_rank = 0
 
-                self.node_memory.zero_()
-                self.node_memory_ts.zero_()
-                self.mailbox.zero_()
-                self.mailbox_ts.zero_()
+            if not shared_memory:
+                self.node_memory = torch.zeros(
+                    (num_nodes, dim_memory), dtype=torch.float32, device=device)
+                self.node_memory_ts = torch.zeros(
+                    num_nodes, dtype=torch.float32, device=device)
+                self.mailbox = torch.zeros(
+                    (num_nodes, self.dim_raw_message),
+                    dtype=torch.float32, device=device)
+                self.mailbox_ts = torch.zeros(
+                    (num_nodes,), dtype=torch.float32, device=device)
+            else:
+                if local_rank == 0:
+                    self.node_memory = create_shared_mem_array(
+                        'node_memory', (num_nodes, dim_memory), dtype=torch.float32)
+                    self.node_memory_ts = create_shared_mem_array(
+                        'node_memory_ts', (num_nodes,), dtype=torch.float32)
+                    self.mailbox = create_shared_mem_array(
+                        'mailbox', (num_nodes, self.dim_raw_message),
+                        dtype=torch.float32)
+                    self.mailbox_ts = create_shared_mem_array(
+                        'mailbox_ts', (num_nodes,), dtype=torch.float32)
 
-            torch.distributed.barrier()
+                    self.node_memory.zero_()
+                    self.node_memory_ts.zero_()
+                    self.mailbox.zero_()
+                    self.mailbox_ts.zero_()
 
-            if local_rank != 0:
-                # NB: `num_nodes` should be same for all local processes because
-                # they share the same local graph
-                self.node_memory = get_shared_mem_array(
-                    'node_memory', (num_nodes, dim_memory), torch.float32)
-                self.node_memory_ts = get_shared_mem_array(
-                    'node_memory_ts', (num_nodes,), torch.float32)
-                self.mailbox = get_shared_mem_array(
-                    'mailbox', (num_nodes, self.dim_raw_message), torch.float32)
-                self.mailbox_ts = get_shared_mem_array(
-                    'mailbox_ts', (num_nodes,), torch.float32)
+                torch.distributed.barrier()
+
+                if local_rank != 0:
+                    # NB: `num_nodes` should be same for all local processes because
+                    # they share the same local graph
+                    self.node_memory = get_shared_mem_array(
+                        'node_memory', (num_nodes, dim_memory), torch.float32)
+                    self.node_memory_ts = get_shared_mem_array(
+                        'node_memory_ts', (num_nodes,), torch.float32)
+                    self.mailbox = get_shared_mem_array(
+                        'mailbox', (num_nodes, self.dim_raw_message), torch.float32)
+                    self.mailbox_ts = get_shared_mem_array(
+                        'mailbox_ts', (num_nodes,), torch.float32)
 
     def reset(self):
         """
         Reset the memory and the mailbox.
         """
-        self.node_memory.fill_(0)
-        self.node_memory_ts.fill_(0)
-        self.mailbox.fill_(0)
-        self.mailbox_ts.fill_(0)
+        if self.partition:
+            self.kvstore_client.reset_memory()
+        else:
+            self.node_memory.fill_(0)
+            self.node_memory_ts.fill_(0)
+            self.mailbox.fill_(0)
+            self.mailbox_ts.fill_(0)
 
     def resize(self, num_nodes):
         """
@@ -149,8 +161,8 @@ class Memory:
 
         Args:
           b: sampled message flow graph (mfg), where
-                `b.num_dst_nodes()` is the number of target nodes to sample, 
-                `b.srcdata['ID']` is the node IDs of all nodes, and 
+                `b.num_dst_nodes()` is the number of target nodes to sample,
+                `b.srcdata['ID']` is the node IDs of all nodes, and
                 `b.srcdata['ts']` is the time stamps of all nodes.
         """
         device = b.device
@@ -159,10 +171,20 @@ class Memory:
         all_nodes = b.srcdata['ID']
         assert isinstance(all_nodes, torch.Tensor)
 
-        b.srcdata['mem'] = self.node_memory[all_nodes].to(device)
-        b.dstdata['mem_ts'] = self.node_memory_ts[target_nodes].to(device)
-        b.dstdata['mail_ts'] = self.mailbox_ts[target_nodes].to(device)
-        b.dstdata['mem_input'] = self.mailbox[target_nodes].to(device)
+        if self.partition:
+            b.srcdata['mem'] = self.kvstore_client.pull(
+                all_nodes.cpu(), mode='memory').to(device)
+            b.srcdata['mem_ts'] = self.kvstore_client.pull(
+                all_nodes.cpu(), mode='memory_ts').to(device)
+            b.srcdata['mail_ts'] = self.kvstore_client.pull(
+                all_nodes.cpu(), mode='mailbox_ts').to(device)
+            b.srcdata['mem_input'] = self.kvstore_client.pull(
+                all_nodes.cpu(), mode='mailbox').to(device)
+        else:
+            b.srcdata['mem'] = self.node_memory[all_nodes].to(device)
+            b.dstdata['mem_ts'] = self.node_memory_ts[target_nodes].to(device)
+            b.dstdata['mail_ts'] = self.mailbox_ts[target_nodes].to(device)
+            b.dstdata['mem_input'] = self.mailbox[target_nodes].to(device)
 
     def update_memory(self, last_updated_nid: torch.Tensor,
                       last_updated_memory: torch.Tensor,
@@ -175,11 +197,17 @@ class Memory:
             last_updated_memory: new memory of the nodes
             last_updated_ts: new timestamp of the nodes
         """
-        last_updated_nid = last_updated_nid.to(self.device)
-        last_updated_memory = last_updated_memory.to(self.device)
-        last_updated_ts = last_updated_ts.to(self.device)
-        self.node_memory[last_updated_nid] = last_updated_memory
-        self.node_memory_ts[last_updated_nid] = last_updated_ts
+        if self.partition:
+            self.kvstore_client.push(
+                last_updated_nid, last_updated_memory, mode='memory')
+            self.kvstore_client.push(
+                last_updated_nid, last_updated_ts, mode='memory_ts')
+        else:
+            last_updated_nid = last_updated_nid.to(self.device)
+            last_updated_memory = last_updated_memory.to(self.device)
+            last_updated_ts = last_updated_ts.to(self.device)
+            self.node_memory[last_updated_nid] = last_updated_memory
+            self.node_memory_ts[last_updated_nid] = last_updated_ts
 
     def update_mailbox(self, last_updated_nid: torch.Tensor,
                        last_updated_memory: torch.Tensor,
@@ -229,5 +257,9 @@ class Memory:
         mail_ts = mail_ts[perm]
 
         # update mailbox
-        self.mailbox[nid] = mail
-        self.mailbox_ts[nid] = mail_ts
+        if self.partition:
+            self.kvstore_client.push(nid, mail, mode='mailbox')
+            self.kvstore_client.push(nid, mail_ts, mode='mailbox_ts')
+        else:
+            self.mailbox[nid] = mail
+            self.mailbox_ts[nid] = mail_ts

--- a/gnnflow/utils.py
+++ b/gnnflow/utils.py
@@ -13,6 +13,18 @@ from dgl.utils.shared_mem import create_shared_mem_array, get_shared_mem_array
 from .dynamic_graph import DynamicGraph
 
 
+def local_world_size():
+    return int(os.environ["LOCAL_WORLD_SIZE"])
+
+
+def local_rank():
+    return int(os.environ["LOCAL_RANK"])
+
+
+def rank():
+    return torch.distributed.get_rank()
+
+
 def get_project_root_dir() -> str:
     return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/scripts/offline_edge_prediction.py
+++ b/scripts/offline_edge_prediction.py
@@ -39,7 +39,7 @@ parser.add_argument("--data", choices=datasets, required=True,
                     help="dataset:" + '|'.join(datasets))
 parser.add_argument("--epoch", help="maximum training epoch",
                     type=int, default=100)
-parser.add_argument("--lr", help='learning rate', type=float, default=0.0005)
+parser.add_argument("--lr", help='learning rate', type=float, default=0.0001)
 parser.add_argument("--num-workers", help="num workers for dataloaders",
                     type=int, default=8)
 parser.add_argument("--num-chunks", help="number of chunks for batch sampler",

--- a/scripts/offline_edge_prediction.py
+++ b/scripts/offline_edge_prediction.py
@@ -172,15 +172,12 @@ def main():
     dgraph = build_dynamic_graph(
         **data_config, device=args.local_rank, dataset_df=full_data)
 
-    num_nodes = dgraph.num_vertices()
-    num_edges = dgraph.num_edges()
+    num_nodes = dgraph.num_vertices() + 1
+    num_edges = dgraph.num_edges() 
     # put the features in shared memory when using distributed training
     node_feats, edge_feats = load_feat(
         args.data, shared_memory=args.distributed,
         local_rank=args.local_rank, local_world_size=args.local_world_size)
-
-    edge_feats = torch.randn(672447, 172)
-    node_feats = torch.randn(10985, 172)
 
     dim_node = 0 if node_feats is None else node_feats.shape[1]
     dim_edge = 0 if edge_feats is None else edge_feats.shape[1]

--- a/scripts/offline_edge_prediction_multi_node.py
+++ b/scripts/offline_edge_prediction_multi_node.py
@@ -65,7 +65,6 @@ parser.add_argument("--partition-strategy", type=str, default="roundrobin",
                     help="partition strategy for distributed training")
 args = parser.parse_args()
 
-
 logging.basicConfig(level=logging.INFO)
 logging.info(args)
 

--- a/scripts/offline_edge_prediction_multi_node_kvstore.py
+++ b/scripts/offline_edge_prediction_multi_node_kvstore.py
@@ -292,7 +292,7 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
     logging.info('Start training...')
     for e in range(args.epoch):
         model.train()
-        cache.reset()
+        # cache.reset()
         total_loss = 0
         cache_edge_ratio_sum = 0
         cache_node_ratio_sum = 0

--- a/scripts/offline_edge_prediction_multi_node_kvstore.py
+++ b/scripts/offline_edge_prediction_multi_node_kvstore.py
@@ -22,7 +22,7 @@ from gnnflow.config import get_default_config
 from gnnflow.data import (DistributedBatchSampler, EdgePredictionDataset,
                           RandomStartBatchSampler, default_collate_ndarray)
 from gnnflow.distributed.dist_graph import DistributedDynamicGraph
-from gnnflow.distributed.kvstore import KVStoreClient, KVStoreServer
+from gnnflow.distributed.kvstore import KVStoreClient
 from gnnflow.models.dgnn import DGNN
 from gnnflow.temporal_sampler import TemporalSampler
 from gnnflow.utils import (EarlyStopMonitor, RandEdgeSampler,

--- a/scripts/offline_edge_prediction_multi_node_kvstore.py
+++ b/scripts/offline_edge_prediction_multi_node_kvstore.py
@@ -292,6 +292,7 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
     logging.info('Start training...')
     for e in range(args.epoch):
         model.train()
+        # TODO: now reset do nothing when using distributed
         cache.reset()
         total_loss = 0
         cache_edge_ratio_sum = 0

--- a/scripts/offline_edge_prediction_multi_node_kvstore.py
+++ b/scripts/offline_edge_prediction_multi_node_kvstore.py
@@ -292,7 +292,7 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
     logging.info('Start training...')
     for e in range(args.epoch):
         model.train()
-        # cache.reset()
+        cache.reset()
         total_loss = 0
         cache_edge_ratio_sum = 0
         cache_node_ratio_sum = 0

--- a/scripts/offline_edge_prediction_multi_node_kvstore.py
+++ b/scripts/offline_edge_prediction_multi_node_kvstore.py
@@ -198,7 +198,7 @@ def main():
         # every worker will have a kvstore_client
         kvstore_client = KVStoreClient(
             dgraph.get_partition_table(),
-            dgraph.num_partitions(), args.world_size)
+            dgraph.num_partitions(), args.local_world_size)
         dim_node, dim_edge = graph_services.get_dim_node_edge()
     else:
         dgraph = build_dynamic_graph(

--- a/scripts/offline_edge_prediction_multi_node_kvstore.py
+++ b/scripts/offline_edge_prediction_multi_node_kvstore.py
@@ -67,7 +67,7 @@ parser.add_argument("--partition-strategy", type=str, default="roundrobin",
                     help="partition strategy for distributed training")
 args = parser.parse_args()
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 logging.info(args)
 
 checkpoint_path = os.path.join(get_project_root_dir(),


### PR DESCRIPTION
- Implement the dist-kvstore logic include cache and memory
- **cache.reset() now do nothing for distributed.**
- Need to carefully merge the training scripts
- I modify a bit of offline_edge_prediction.py so that it can work well with current cache and model API
- Run two comparsion exp: 
- 1. use offline_edge_prediction.py and run on g2 using 2 GPU. LR = 0.0001. (White one)
- 2. use offline_edge_prediction_multi_node_kv_store.py and run on aws using 2 GPU. LR = 0.0001 (Black one)
- Now the accuracy is aligned, but the throughput is 65x slower. See pictures
**g2-2GPU**
![9651665504456_ pic](https://user-images.githubusercontent.com/43173188/195144831-9615b62d-4002-48d0-b711-789eb6940a3f.jpg)
**AWS distributed 2GPU**
![9641665504376_ pic](https://user-images.githubusercontent.com/43173188/195144950-e9a62cac-d275-4363-b318-9a201c754aa3.jpg)

