### PR TITLE
Optim kvstore

### DIFF
--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -279,10 +279,8 @@ class KVStoreClient:
             # TODO: try to concate to tensor and split them
             all_mem[idx] = pull_result[:, 2:102]
             all_mem_ts[idx] = pull_result[:, 0]
-            all_mail[idx] = pull_result[2]
-            logging.info("mail size {}".format(pull_result[:, 102:].shape))
-            logging.info("all shape:{}".format(pull_result.shape))
-            all_mail_ts[idx] = pull_result[:, 102:]
+            all_mail[idx] = pull_result[:, 102:]
+            all_mail_ts[idx] = pull_result[:, 1]
             # all_mem[idx] = pull_result[0]
             # all_mem_ts[idx] = pull_result[1]
             # all_mail[idx] = pull_result[2]

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import torch
 import torch.distributed.rpc as rpc

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -1,3 +1,5 @@
+import logging
+import time
 from typing import List, Optional
 
 import torch
@@ -75,7 +77,16 @@ class KVStoreServer:
         elif mode == 'edge':
             return torch.stack([self._edge_feat_map[int(key)] for key in keys])
         elif mode == 'memory':
-            return torch.stack([self._memory_map[int(key)] for key in keys])
+            mem = torch.stack([self._memory_map[int(key)] for key in keys])
+            mem_ts = torch.stack([self._memory_ts_map[int(key)] for key in keys])
+            mail = torch.stack([self._mailbox_map[int(key)] for key in keys])
+            mail_ts = torch.stack([self._mailbox_ts_map[int(key)] for key in keys])
+            return (mem, mem_ts, mail, mail_ts)
+            # start = time.time()
+            # temp = torch.stack([self._memory_map[int(key)] for key in keys])
+            # end = time.time()
+            # logging.info("exclude rpc time: {}".format(end - start))
+            # return temp
         elif mode == 'memory_ts':
             return torch.stack([self._memory_ts_map[int(key)] for key in keys])
         elif mode == 'mailbox':

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -260,7 +260,7 @@ class KVStoreClient:
 
         all_pull_results = 0
         for pull_result in pull_results:
-            all_pull_results += len(pull_result[0])
+            all_pull_results += len(pull_result)
 
         # torch scalar
         all_mem_ts = torch.zeros((all_pull_results,), dtype=torch.float32)
@@ -280,6 +280,8 @@ class KVStoreClient:
             all_mem[idx] = pull_result[:, 2:102]
             all_mem_ts[idx] = pull_result[:, 0]
             all_mail[idx] = pull_result[2]
+            logging.info("mail size {}".format(pull_result[:, 102:].shape))
+            logging.info("all shape:{}".format(pull_result.shape))
             all_mail_ts[idx] = pull_result[:, 102:]
             # all_mem[idx] = pull_result[0]
             # all_mem_ts[idx] = pull_result[1]

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -1,5 +1,3 @@
-import logging
-import time
 from typing import List, Optional
 
 import torch
@@ -77,16 +75,7 @@ class KVStoreServer:
         elif mode == 'edge':
             return torch.stack([self._edge_feat_map[int(key)] for key in keys])
         elif mode == 'memory':
-            mem = torch.stack([self._memory_map[int(key)] for key in keys])
-            mem_ts = torch.stack([self._memory_ts_map[int(key)] for key in keys])
-            mail = torch.stack([self._mailbox_map[int(key)] for key in keys])
-            mail_ts = torch.stack([self._mailbox_ts_map[int(key)] for key in keys])
-            return (mem, mem_ts, mail, mail_ts)
-            # start = time.time()
-            # temp = torch.stack([self._memory_map[int(key)] for key in keys])
-            # end = time.time()
-            # logging.info("exclude rpc time: {}".format(end - start))
-            # return temp
+            return torch.stack([self._memory_map[int(key)] for key in keys])
         elif mode == 'memory_ts':
             return torch.stack([self._memory_ts_map[int(key)] for key in keys])
         elif mode == 'mailbox':

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -114,16 +114,16 @@ class KVStoreClient:
                  num_partitions: int,
                  num_workers_per_machine: int,
                  local_rank: int,
-                 dim_edge_feat: int = 0,
                  dim_node_feat: int = 0,
+                 dim_edge_feat: int = 0,
                  dim_memory: int = 0):
         self._partition_table = partition_table
         self._num_partitions = num_partitions
         self._num_workers_per_machine = num_workers_per_machine
         self._local_rank = local_rank
 
-        self._dim_edge_feat = dim_edge_feat
         self._dim_node_feat = dim_node_feat
+        self._dim_edge_feat = dim_edge_feat
         self._dim_memory = dim_memory
         self._dim_mail = dim_memory * 2 + self._dim_edge_feat
 

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -147,8 +147,8 @@ class KVStoreClient:
             futures.append(rpc.rpc_async('worker{}'.format(worker_rank),
                                          graph_services.push_tensors, args=(partition_keys, partition_tensors, mode)))
 
-        for future in futures:
-            future.wait()
+        # for future in futures:
+        #     future.wait()
 
     def pull(self, keys: torch.Tensor, mode: str, nid: Optional[torch.Tensor] = None) -> torch.Tensor:
         """

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List, Optional
 
 import torch
@@ -78,6 +79,7 @@ class KVStoreServer:
             mem = torch.stack([self._memory_map[int(key)] for key in keys])
             mem_ts = torch.stack([self._memory_ts_map[int(key)] for key in keys])
             mail = torch.stack([self._mailbox_map[int(key)] for key in keys])
+            logging.info('mail shape: {}'.format(mail.shape))
             mail_ts = torch.stack([self._mailbox_ts_map[int(key)] for key in keys])
             return (mem, mem_ts, mail, mail_ts)
             # return torch.stack([self._memory_map[int(key)] for key in keys])
@@ -262,7 +264,7 @@ class KVStoreClient:
         all_mem = torch.zeros(
                 (all_pull_results, pull_results[0][0][0].shape[0]), dtype=torch.float32)
         all_mail = torch.zeros(
-                (all_pull_results, pull_results[0][0][2].shape[0]), dtype=torch.float32)
+                (all_pull_results, pull_results[0][2][0].shape[0]), dtype=torch.float32)
         # if pull_results[0][0][].shape == torch.Size([]):
         #     all_pull_results = torch.zeros(
         #         (all_pull_results,), dtype=torch.float32)

--- a/gnnflow/distributed/kvstore.py
+++ b/gnnflow/distributed/kvstore.py
@@ -76,10 +76,10 @@ class KVStoreServer:
         elif mode == 'edge':
             return torch.stack([self._edge_feat_map[int(key)] for key in keys])
         elif mode == 'memory':
+            # TODO: try to concat to tensor
             mem = torch.stack([self._memory_map[int(key)] for key in keys])
             mem_ts = torch.stack([self._memory_ts_map[int(key)] for key in keys])
             mail = torch.stack([self._mailbox_map[int(key)] for key in keys])
-            logging.info('mail shape: {}'.format(mail.shape))
             mail_ts = torch.stack([self._mailbox_ts_map[int(key)] for key in keys])
             return (mem, mem_ts, mail, mail_ts)
             # return torch.stack([self._memory_map[int(key)] for key in keys])
@@ -265,15 +265,10 @@ class KVStoreClient:
                 (all_pull_results, pull_results[0][0][0].shape[0]), dtype=torch.float32)
         all_mail = torch.zeros(
                 (all_pull_results, pull_results[0][2][0].shape[0]), dtype=torch.float32)
-        # if pull_results[0][0][].shape == torch.Size([]):
-        #     all_pull_results = torch.zeros(
-        #         (all_pull_results,), dtype=torch.float32)
-        # else:
-        #     all_pull_results = torch.zeros(
-        #         (all_pull_results, pull_results[0][0].shape[0]), dtype=torch.float32)
 
         for mask, pull_result in zip(masks, pull_results):
             idx = mask.nonzero().squeeze()
+            # TODO: try to concate to tensor and split them
             all_mem[idx] = pull_result[0]
             all_mem_ts[idx] = pull_result[1]
             all_mail[idx] = pull_result[2]

--- a/gnnflow/models/modules/memory.py
+++ b/gnnflow/models/modules/memory.py
@@ -178,26 +178,23 @@ class Memory:
             # b.srcdata['mem_input'] = mail.to(device)
             # unique all nodes
             all_nodes_unique, counts = torch.unique(all_nodes.cpu(), return_counts=True)
-            mem = torch.repeat_interleave(self.kvstore_client.pull(
-                all_nodes_unique, mode='memory'), counts, dim=0).to(device)
-            mem_ts = torch.repeat_interleave(self.kvstore_client.pull(
-                all_nodes_unique, mode='memory_ts'), counts, dim=0).to(device)
-            mail = torch.repeat_interleave(self.kvstore_client.pull(
-                all_nodes_unique, mode='mailbox'), counts, dim=0).to(device)
-            mail_ts = torch.repeat_interleave(self.kvstore_client.pull(
-                all_nodes_unique, mode='mailbox_ts'), counts, dim=0).to(device)
+            mem_mail = self.kvstore_client.pull(all_nodes_unique, mode='memory')
+            mem = torch.repeat_interleave(mem_mail[0], counts, dim=0).to(device)
+            mem_ts = torch.repeat_interleave(mem_mail[1], counts, dim=0).to(device)
+            mail = torch.repeat_interleave(mem_mail[2], counts, dim=0).to(device)
+            mail_ts = torch.repeat_interleave(mem_mail[3], counts, dim=0).to(device)
+            # mem = torch.repeat_interleave(self.kvstore_client.pull(
+            #     all_nodes_unique, mode='memory'), counts, dim=0).to(device)
+            # mem_ts = torch.repeat_interleave(self.kvstore_client.pull(
+            #     all_nodes_unique, mode='memory_ts'), counts, dim=0).to(device)
+            # mail = torch.repeat_interleave(self.kvstore_client.pull(
+            #     all_nodes_unique, mode='mailbox'), counts, dim=0).to(device)
+            # mail_ts = torch.repeat_interleave(self.kvstore_client.pull(
+            #     all_nodes_unique, mode='mailbox_ts'), counts, dim=0).to(device)
             b.srcdata['mem'] = mem
             b.srcdata['mem_ts'] = mem_ts
             b.srcdata['mail_ts'] = mail_ts
             b.srcdata['mem_input'] = mail
-            # b.srcdata['mem'] = self.kvstore_client.pull(
-            #     all_nodes.cpu(), mode='memory').to(device)
-            # b.srcdata['mem_ts'] = self.kvstore_client.pull(
-            #     all_nodes.cpu(), mode='memory_ts').to(device)
-            # b.srcdata['mail_ts'] = self.kvstore_client.pull(
-            #     all_nodes.cpu(), mode='mailbox_ts').to(device)
-            # b.srcdata['mem_input'] = self.kvstore_client.pull(
-            #     all_nodes.cpu(), mode='mailbox').to(device)
         else:
             b.srcdata['mem'] = self.node_memory[all_nodes].to(device)
             b.srcdata['mem_ts'] = self.node_memory_ts[all_nodes].to(device)

--- a/gnnflow/models/modules/memory.py
+++ b/gnnflow/models/modules/memory.py
@@ -178,19 +178,19 @@ class Memory:
             # b.srcdata['mem_input'] = mail.to(device)
             # unique all nodes
             all_nodes_unique, counts = torch.unique(all_nodes.cpu(), return_counts=True)
-            mem_mail = self.kvstore_client.pull(all_nodes_unique, mode='memory')
-            mem = torch.repeat_interleave(mem_mail[0], counts, dim=0).to(device)
-            mem_ts = torch.repeat_interleave(mem_mail[1], counts, dim=0).to(device)
-            mail = torch.repeat_interleave(mem_mail[2], counts, dim=0).to(device)
-            mail_ts = torch.repeat_interleave(mem_mail[3], counts, dim=0).to(device)
-            # mem = torch.repeat_interleave(self.kvstore_client.pull(
-            #     all_nodes_unique, mode='memory'), counts, dim=0).to(device)
-            # mem_ts = torch.repeat_interleave(self.kvstore_client.pull(
-            #     all_nodes_unique, mode='memory_ts'), counts, dim=0).to(device)
-            # mail = torch.repeat_interleave(self.kvstore_client.pull(
-            #     all_nodes_unique, mode='mailbox'), counts, dim=0).to(device)
-            # mail_ts = torch.repeat_interleave(self.kvstore_client.pull(
-            #     all_nodes_unique, mode='mailbox_ts'), counts, dim=0).to(device)
+            # mem_mail = self.kvstore_client.pull(all_nodes_unique, mode='memory')
+            # mem = torch.repeat_interleave(mem_mail[0], counts, dim=0).to(device)
+            # mem_ts = torch.repeat_interleave(mem_mail[1], counts, dim=0).to(device)
+            # mail = torch.repeat_interleave(mem_mail[2], counts, dim=0).to(device)
+            # mail_ts = torch.repeat_interleave(mem_mail[3], counts, dim=0).to(device)
+            mem = torch.repeat_interleave(self.kvstore_client.pull(
+                all_nodes_unique, mode='memory'), counts, dim=0).to(device)
+            mem_ts = torch.repeat_interleave(self.kvstore_client.pull(
+                all_nodes_unique, mode='memory_ts'), counts, dim=0).to(device)
+            mail = torch.repeat_interleave(self.kvstore_client.pull(
+                all_nodes_unique, mode='mailbox'), counts, dim=0).to(device)
+            mail_ts = torch.repeat_interleave(self.kvstore_client.pull(
+                all_nodes_unique, mode='mailbox_ts'), counts, dim=0).to(device)
             b.srcdata['mem'] = mem
             b.srcdata['mem_ts'] = mem_ts
             b.srcdata['mail_ts'] = mail_ts

--- a/gnnflow/models/modules/memory.py
+++ b/gnnflow/models/modules/memory.py
@@ -186,11 +186,6 @@ class Memory:
 
             mem = self.kvstore_client.pull(
                 all_nodes_unique, mode='memory')[inv].to(device)
-            # mem_2 = self.kvstore_client.pull(
-            #     all_nodes.cpu(), mode='memory').to(device)
-            # logging.info("mem: {}".format(mem.shape))
-            # logging.info("mem not unqiue: {}".format(mem_2.shape))
-            # assert torch.allclose(mem, mem_2), "the unique function is error"
             mem_ts = self.kvstore_client.pull(
                 all_nodes_unique, mode='memory_ts')[inv].to(device)
             mail = self.kvstore_client.pull(
@@ -210,13 +205,7 @@ class Memory:
             # b.srcdata['mem_input'] = self.kvstore_client.pull(
             #     all_nodes.cpu(), mode='mailbox').to(device)
         else:
-            all_nodes_unique, inv, counts = torch.unique(all_nodes, return_inverse=True, return_counts=True)
-            mem = self.node_memory[all_nodes].to(device)
-            mem_2 = self.node_memory[all_nodes_unique][inv].to(device)
-            # logging.info("mem: {}".format(mem.shape))
-            # logging.info("mem not unqiue: {}".format(mem_2.shape))
-            assert torch.allclose(mem, mem_2), "the unique function is error"
-            b.srcdata['mem'] = mem
+            b.srcdata['mem'] = self.node_memory[all_nodes].to(device)
             b.srcdata['mem_ts'] = self.node_memory_ts[all_nodes].to(device)
             b.srcdata['mail_ts'] = self.mailbox_ts[all_nodes].to(device)
             b.srcdata['mem_input'] = self.mailbox[all_nodes].to(device)

--- a/gnnflow/models/modules/memory.py
+++ b/gnnflow/models/modules/memory.py
@@ -175,7 +175,7 @@ class Memory:
             mem = pulled_memory[0][inv].to(device)
             mem_ts = pulled_memory[1][inv].to(device)
             mail = pulled_memory[2][inv].to(device)
-            mail_ts = pull_memory[3][inv].to(device)
+            mail_ts = pulled_memory[3][inv].to(device)
 
             b.srcdata['mem'] = mem
             b.srcdata['mem_ts'] = mem_ts

--- a/gnnflow/models/modules/memory.py
+++ b/gnnflow/models/modules/memory.py
@@ -178,32 +178,24 @@ class Memory:
             # b.srcdata['mem_input'] = mail.to(device)
             # unique all nodes
             all_nodes_unique, inv = torch.unique(all_nodes.cpu(), return_inverse=True)
-            # mem_mail = self.kvstore_client.pull(all_nodes_unique, mode='memory')
-            # mem = torch.repeat_interleave(mem_mail[0], counts, dim=0).to(device)
-            # mem_ts = torch.repeat_interleave(mem_mail[1], counts, dim=0).to(device)
-            # mail = torch.repeat_interleave(mem_mail[2], counts, dim=0).to(device)
-            # mail_ts = torch.repeat_interleave(mem_mail[3], counts, dim=0).to(device)
+            mem_mail = self.kvstore_client.pull(all_nodes_unique, mode='memory')
+            mem = mem_mail[0][inv].to(device)
+            mem_ts = mem_mail[1][inv].to(device)
+            mail = mem_mail[2][inv].to(device)
+            mail_ts = mem_mail[3][inv].to(device)
 
-            mem = self.kvstore_client.pull(
-                all_nodes_unique, mode='memory')[inv].to(device)
-            mem_ts = self.kvstore_client.pull(
-                all_nodes_unique, mode='memory_ts')[inv].to(device)
-            mail = self.kvstore_client.pull(
-                all_nodes_unique, mode='mailbox')[inv].to(device)
-            mail_ts = self.kvstore_client.pull(
-                all_nodes_unique, mode='mailbox_ts')[inv].to(device)
+            # mem = self.kvstore_client.pull(
+            #     all_nodes_unique, mode='memory')[inv].to(device)
+            # mem_ts = self.kvstore_client.pull(
+            #     all_nodes_unique, mode='memory_ts')[inv].to(device)
+            # mail = self.kvstore_client.pull(
+            #     all_nodes_unique, mode='mailbox')[inv].to(device)
+            # mail_ts = self.kvstore_client.pull(
+            #     all_nodes_unique, mode='mailbox_ts')[inv].to(device)
             b.srcdata['mem'] = mem
             b.srcdata['mem_ts'] = mem_ts
             b.srcdata['mail_ts'] = mail_ts
             b.srcdata['mem_input'] = mail
-            # b.srcdata['mem'] = self.kvstore_client.pull(
-            #     all_nodes.cpu(), mode='memory').to(device)
-            # b.srcdata['mem_ts'] = self.kvstore_client.pull(
-            #     all_nodes.cpu(), mode='memory_ts').to(device)
-            # b.srcdata['mail_ts'] = self.kvstore_client.pull(
-            #     all_nodes.cpu(), mode='mailbox_ts').to(device)
-            # b.srcdata['mem_input'] = self.kvstore_client.pull(
-            #     all_nodes.cpu(), mode='mailbox').to(device)
         else:
             b.srcdata['mem'] = self.node_memory[all_nodes].to(device)
             b.srcdata['mem_ts'] = self.node_memory_ts[all_nodes].to(device)

--- a/gnnflow/models/modules/memory.py
+++ b/gnnflow/models/modules/memory.py
@@ -170,14 +170,33 @@ class Memory:
         assert isinstance(all_nodes, torch.Tensor)
 
         if self.partition:
-            b.srcdata['mem'] = self.kvstore_client.pull(
-                all_nodes.cpu(), mode='memory').to(device)
-            b.srcdata['mem_ts'] = self.kvstore_client.pull(
-                all_nodes.cpu(), mode='memory_ts').to(device)
-            b.srcdata['mail_ts'] = self.kvstore_client.pull(
-                all_nodes.cpu(), mode='mailbox_ts').to(device)
-            b.srcdata['mem_input'] = self.kvstore_client.pull(
-                all_nodes.cpu(), mode='mailbox').to(device)
+            # mem, mem_ts, mail_ts, mail = self.kvstore_client.pull(all_nodes.cpu(), mode='memory')
+            # b.srcdata['mem'] = mem.to(device)
+            # b.srcdata['mem_ts'] = mem_ts.to(device)
+            # b.srcdata['mail_ts'] = mail_ts.to(device)
+            # b.srcdata['mem_input'] = mail.to(device)
+            # unique all nodes
+            all_nodes_unique, inv = torch.unique(all_nodes.cpu(), return_inverse=True)
+            mem = torch.take(self.kvstore_client.pull(
+                all_nodes_unique, mode='memory'), inv).to(device)
+            mem_ts = torch.take(self.kvstore_client.pull(
+                all_nodes_unique, mode='memory_ts'), inv).to(device)
+            mail = torch.take(self.kvstore_client.pull(
+                all_nodes_unique, mode='mailbox'), inv).to(device)
+            mail_ts = torch.take(self.kvstore_client.pull(
+                all_nodes_unique, mode='mailbox_ts'), inv).to(device)
+            b.srcdata['mem'] = mem
+            b.srcdata['mem_ts'] = mem_ts
+            b.srcdata['mail_ts'] = mail_ts
+            b.srcdata['mem_input'] = mail
+            # b.srcdata['mem'] = self.kvstore_client.pull(
+            #     all_nodes.cpu(), mode='memory').to(device)
+            # b.srcdata['mem_ts'] = self.kvstore_client.pull(
+            #     all_nodes.cpu(), mode='memory_ts').to(device)
+            # b.srcdata['mail_ts'] = self.kvstore_client.pull(
+            #     all_nodes.cpu(), mode='mailbox_ts').to(device)
+            # b.srcdata['mem_input'] = self.kvstore_client.pull(
+            #     all_nodes.cpu(), mode='mailbox').to(device)
         else:
             b.srcdata['mem'] = self.node_memory[all_nodes].to(device)
             b.srcdata['mem_ts'] = self.node_memory_ts[all_nodes].to(device)

--- a/gnnflow/models/modules/memory.py
+++ b/gnnflow/models/modules/memory.py
@@ -183,18 +183,27 @@ class Memory:
             # mem_ts = torch.repeat_interleave(mem_mail[1], counts, dim=0).to(device)
             # mail = torch.repeat_interleave(mem_mail[2], counts, dim=0).to(device)
             # mail_ts = torch.repeat_interleave(mem_mail[3], counts, dim=0).to(device)
-            mem = torch.repeat_interleave(self.kvstore_client.pull(
-                all_nodes_unique, mode='memory'), counts, dim=0).to(device)
-            mem_ts = torch.repeat_interleave(self.kvstore_client.pull(
-                all_nodes_unique, mode='memory_ts'), counts, dim=0).to(device)
-            mail = torch.repeat_interleave(self.kvstore_client.pull(
-                all_nodes_unique, mode='mailbox'), counts, dim=0).to(device)
-            mail_ts = torch.repeat_interleave(self.kvstore_client.pull(
-                all_nodes_unique, mode='mailbox_ts'), counts, dim=0).to(device)
-            b.srcdata['mem'] = mem
-            b.srcdata['mem_ts'] = mem_ts
-            b.srcdata['mail_ts'] = mail_ts
-            b.srcdata['mem_input'] = mail
+
+            # mem = torch.repeat_interleave(self.kvstore_client.pull(
+            #     all_nodes_unique, mode='memory'), counts, dim=0).to(device)
+            # mem_ts = torch.repeat_interleave(self.kvstore_client.pull(
+            #     all_nodes_unique, mode='memory_ts'), counts, dim=0).to(device)
+            # mail = torch.repeat_interleave(self.kvstore_client.pull(
+            #     all_nodes_unique, mode='mailbox'), counts, dim=0).to(device)
+            # mail_ts = torch.repeat_interleave(self.kvstore_client.pull(
+            #     all_nodes_unique, mode='mailbox_ts'), counts, dim=0).to(device)
+            # b.srcdata['mem'] = mem
+            # b.srcdata['mem_ts'] = mem_ts
+            # b.srcdata['mail_ts'] = mail_ts
+            # b.srcdata['mem_input'] = mail
+            b.srcdata['mem'] = self.kvstore_client.pull(
+                all_nodes.cpu(), mode='memory').to(device)
+            b.srcdata['mem_ts'] = self.kvstore_client.pull(
+                all_nodes.cpu(), mode='memory_ts').to(device)
+            b.srcdata['mail_ts'] = self.kvstore_client.pull(
+                all_nodes.cpu(), mode='mailbox_ts').to(device)
+            b.srcdata['mem_input'] = self.kvstore_client.pull(
+                all_nodes.cpu(), mode='mailbox').to(device)
         else:
             b.srcdata['mem'] = self.node_memory[all_nodes].to(device)
             b.srcdata['mem_ts'] = self.node_memory_ts[all_nodes].to(device)

--- a/gnnflow/models/modules/memory.py
+++ b/gnnflow/models/modules/memory.py
@@ -169,27 +169,14 @@ class Memory:
         assert isinstance(all_nodes, torch.Tensor)
 
         if self.partition:
-            # mem, mem_ts, mail_ts, mail = self.kvstore_client.pull(all_nodes.cpu(), mode='memory')
-            # b.srcdata['mem'] = mem.to(device)
-            # b.srcdata['mem_ts'] = mem_ts.to(device)
-            # b.srcdata['mail_ts'] = mail_ts.to(device)
-            # b.srcdata['mem_input'] = mail.to(device)
             # unique all nodes
             all_nodes_unique, inv = torch.unique(all_nodes.cpu(), return_inverse=True)
-            mem_mail = self.kvstore_client.pull(all_nodes_unique, mode='memory')
-            mem = mem_mail[0][inv].to(device)
-            mem_ts = mem_mail[1][inv].to(device)
-            mail = mem_mail[2][inv].to(device)
-            mail_ts = mem_mail[3][inv].to(device)
+            pulled_memory = self.kvstore_client.pull(all_nodes_unique, mode='memory')
+            mem = pulled_memory[0][inv].to(device)
+            mem_ts = pulled_memory[1][inv].to(device)
+            mail = pulled_memory[2][inv].to(device)
+            mail_ts = pull_memory[3][inv].to(device)
 
-            # mem = self.kvstore_client.pull(
-            #     all_nodes_unique, mode='memory')[inv].to(device)
-            # mem_ts = self.kvstore_client.pull(
-            #     all_nodes_unique, mode='memory_ts')[inv].to(device)
-            # mail = self.kvstore_client.pull(
-            #     all_nodes_unique, mode='mailbox')[inv].to(device)
-            # mail_ts = self.kvstore_client.pull(
-            #     all_nodes_unique, mode='mailbox_ts')[inv].to(device)
             b.srcdata['mem'] = mem
             b.srcdata['mem_ts'] = mem_ts
             b.srcdata['mail_ts'] = mail_ts

--- a/gnnflow/models/modules/memory.py
+++ b/gnnflow/models/modules/memory.py
@@ -181,11 +181,11 @@ class Memory:
             mem = torch.repeat_interleave(self.kvstore_client.pull(
                 all_nodes_unique, mode='memory'), counts, dim=0).to(device)
             mem_ts = torch.repeat_interleave(self.kvstore_client.pull(
-                all_nodes_unique, mode='memory_ts'), counts).to(device)
+                all_nodes_unique, mode='memory_ts'), counts, dim=0).to(device)
             mail = torch.repeat_interleave(self.kvstore_client.pull(
-                all_nodes_unique, mode='mailbox'), counts).to(device)
+                all_nodes_unique, mode='mailbox'), counts, dim=0).to(device)
             mail_ts = torch.repeat_interleave(self.kvstore_client.pull(
-                all_nodes_unique, mode='mailbox_ts'), counts).to(device)
+                all_nodes_unique, mode='mailbox_ts'), counts, dim=0).to(device)
             b.srcdata['mem'] = mem
             b.srcdata['mem_ts'] = mem_ts
             b.srcdata['mail_ts'] = mail_ts

--- a/scripts/offline_edge_prediction_multi_node_kvstore.py
+++ b/scripts/offline_edge_prediction_multi_node_kvstore.py
@@ -198,11 +198,11 @@ def main():
                                        args.num_nodes, data_config["undirected"], args.data,
                                        args.dim_memory)
         # every worker will have a kvstore_client
+        dim_node, dim_edge = graph_services.get_dim_node_edge()
         kvstore_client = KVStoreClient(
             dgraph.get_partition_table(),
             dgraph.num_partitions(), args.local_world_size,
-            args.local_rank)
-        dim_node, dim_edge = graph_services.get_dim_node_edge()
+            args.local_rank, dim_node, dim_edge, args.dim_memory)
     else:
         dgraph = build_dynamic_graph(
             **data_config, device=args.local_rank, dataset_df=full_data)

--- a/scripts/run_offline_multi_node_g4_4.sh
+++ b/scripts/run_offline_multi_node_g4_4.sh
@@ -9,7 +9,7 @@ PARTITION_STRATEGY="${5:-hash}"
 
 HOST_NODE_ADDR=172.31.33.18
 HOST_NODE_PORT=29400
-NNODES=4
+NNODES=2
 NPROC_PER_NODE=1
 
 CURRENT_NODE_IP=$(ip -4 a show dev ${INTERFACE} | grep inet | cut -d " " -f6 | cut -d "/" -f1)
@@ -28,7 +28,7 @@ cmd="torchrun \
     --rdzv_id=1234 --rdzv_backend=c10d \
     --rdzv_endpoint=$HOST_NODE_ADDR:$HOST_NODE_PORT \
     --rdzv_conf is_host=$IS_HOST \
-    offline_edge_prediction_multi_node.py --model $MODEL --data $DATA \
+    offline_edge_prediction_multi_node_kvstore.py --model $MODEL --data $DATA \
     --cache $CACHE --cache-ratio $CACHE_RATIO \
     --partition --ingestion-batch-size 100000 \
     --partition-strategy $PARTITION_STRATEGY \


### PR DESCRIPTION
Now three optimizations were made:
1. The first was to perform a `unique` and `restore` operation on `all_nodes` during pulling the memory. The throughput is  advanced from 5k -> 8k.
2. The second is to remove `futures.wait()` when pushing the memory back to the kvstore. The throughput is advanced from 8k -> 11k
3. The third is to return four values in one rpc pull memory. Now the throughput of TGN is 14k. I cat these four values into a tensor and then slice them, which will be a little faster than return them using a tuple.

The profiling data is as below:
**Not optimized:**
pull mem time: 0.5s
push mem time: 0.07s
<img width="1146" alt="截屏2022-10-17 下午5 10 51" src="https://user-images.githubusercontent.com/43173188/196590442-a439634f-beb1-4b2e-85dd-8a7c91b4dbc3.png">

**Optimized:**
pull mem time: 0.1s
push mem time: 0.04s
<img width="1154" alt="截屏2022-10-18 下午8 04 59" src="https://user-images.githubusercontent.com/43173188/196590392-bf47a43c-2f8a-49fa-ba89-adab6d0ba816.png">

