### PR TITLE
fix: sampling merge index error bug

### DIFF
--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -209,14 +209,8 @@ class DistributedTemporalSampler:
             eids = sampling_result.eids
 
             mask = masks[i]
-            dst_idx = mask.nonzero().squeeze().numpy()
-            try:
-                all_row[offset:offset + num_edges] = dst_idx[sampling_result.row]
-            except IndexError:
-                print('dst_idx', dst_idx)
-                print('sampling_result.row', sampling_result.row)
-                raise
-
+            dst_idx = mask.nonzero().squeeze(dim=1).numpy()
+            all_row[offset:offset + num_edges] = dst_idx[sampling_result.row]
             all_dst_nodes[dst_idx] = dst_nodes
             all_dst_timestamps[dst_idx] = dst_timestamps
 

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -210,7 +210,12 @@ class DistributedTemporalSampler:
 
             mask = masks[i]
             dst_idx = mask.nonzero().squeeze().numpy()
-            all_row[offset:offset + num_edges] = dst_idx[sampling_result.row]
+            try:
+                all_row[offset:offset + num_edges] = dst_idx[sampling_result.row]
+            except IndexError:
+                print('dst_idx', dst_idx)
+                print('sampling_result.row', sampling_result.row)
+                raise
 
             all_dst_nodes[dst_idx] = dst_nodes
             all_dst_timestamps[dst_idx] = dst_timestamps


### PR DESCRIPTION
fix https://github.com/jasperzhong/GNNFlow/issues/67

`torch.squeeze()` would squeeze more than one dimensions if the tensor only has one element. 

```py
>>> x = torch.tensor([[0]])
>>> x.squeeze()
tensor(0)
>>> x.squeeze(dim=1)
tensor([0])
```