### PR TITLE
feat: dynamic scheduling

### DIFF
--- a/gnnflow/config.py
+++ b/gnnflow/config.py
@@ -161,7 +161,7 @@ _gdelt_default_config = {
     "undirected": False,
     "node_feature": True,
     "edge_feature": True,
-    "batch_size": 600
+    "batch_size": 4000
 }
 
 _mag_default_config = {

--- a/gnnflow/csrc/dynamic_graph.cu
+++ b/gnnflow/csrc/dynamic_graph.cu
@@ -267,16 +267,8 @@ std::vector<std::size_t> DynamicGraph::out_degree(
     const std::vector<NIDType>& nodes) const {
   std::vector<size_t> out_degrees;
   for (auto& node : nodes) {
-    size_t out_degree = 0;
-    {
-      auto& list = h_copy_of_d_node_table_[node];
-      auto block = list.tail;
-      while (block != nullptr) {
-        out_degree += block->size;
-        block = block->prev;
-      }
-    }
-    out_degrees.push_back(out_degree);
+    auto h_list = h_copy_of_d_node_table_[node];
+    out_degrees.push_back(h_list.num_edges);
   }
   return out_degrees;
 }

--- a/gnnflow/distributed/dist_context.py
+++ b/gnnflow/distributed/dist_context.py
@@ -39,6 +39,7 @@ def initialize(rank: int, world_size: int, dataset: pd.DataFrame,
     rpc.init_rpc("worker%d" % rank, rank=rank, world_size=world_size,
                  rpc_backend_options=rpc.TensorPipeRpcBackendOptions(
                      rpc_timeout=1800,
+                     num_worker_threads=32,
                      _transports=["shm", "uv"],
                      _channels=["cma", "mpt_uv", "basic", "cuda_xth", "cuda_ipc", "cuda_basic"]))
     logging.info("Rank %d: Initialized RPC.", rank)

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -56,7 +56,7 @@ class DistributedTemporalSampler:
         # profiling
         self._sampling_time = torch.zeros(self._num_partitions)
         if dynamic_scheduling:
-            self._gen = torch.Generator()
+            self._beta = 0.5
             self._sampling_weight_matrix = torch.ones(
                 self._num_partitions, self._local_world_size)
 
@@ -117,7 +117,8 @@ class DistributedTemporalSampler:
             weight = all_sampling_time.clone()
             weight = weight.sum(dim=1, keepdim=True) / weight
             weight = torch.softmax(weight, dim=1)
-            self._sampling_weight_matrix = weight
+            self._sampling_weight_matrix *= self._beta
+            self._sampling_weight_matrix += (1 - self._beta) * weight
         
         # reset
         self._sampling_time.zero_()

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -111,8 +111,8 @@ class DistributedTemporalSampler:
         result = torch.zeros(self._num_partitions, self._local_world_size)
         for i in range(self._num_partitions):
             for j in range(self._local_world_size):
-                for i in range(self._num_partitions):
-                    result[i][j] = all_sampling_time[i * self._local_world_size + j][i]
+                for k in range(self._num_partitions):
+                    result[i][j] = all_sampling_time[k * self._local_world_size + j][i]
                 
         if self._dynamic_scheduling:
             weight = result.clone()

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -350,6 +350,9 @@ class DistributedTemporalSampler:
 
         # update load table
         load = len(target_vertices)
+        if min_load_global_rank != self._rank:
+            load *= 1.2
+
         with self._load_table_lock:
             self._load_table[min_load_local_rank] += load
 

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -56,8 +56,7 @@ class DistributedTemporalSampler:
         # profiling
         self._sampling_time = torch.zeros(self._num_partitions)
         if dynamic_scheduling:
-            self._generator = torch.Generator()
-            self._sampling_weight_matrix = torch.ones(
+            self._sampling_weight_matrix = np.ones(
                 self._num_partitions, self._local_world_size)
 
     def _sampling_loop(self):
@@ -192,8 +191,8 @@ class DistributedTemporalSampler:
                     # use weight matrix to decide which partition to sample
                     weight_matrix = self._sampling_weight_matrix[partition_id]
                     worker_rank = partition_id * self._local_world_size + \
-                        torch.multinomial(weight_matrix, 1,
-                                          generator=self._generator).item()
+                        np.random.choice(
+                            self._local_world_size, p=weight_matrix)
 
                 logging.debug(
                     "worker %d call remote sample_layer_local on worker %d", self._rank, worker_rank)

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -120,6 +120,8 @@ class DistributedTemporalSampler:
             self._sampling_weight_matrix = weight
             if self._local_rank == 0:
                 print(f"weight: {weight}")
+        
+        self._sampling_time.zero_()
 
         return all_sampling_time
 

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -340,8 +340,11 @@ class DistributedTemporalSampler:
         assert self._local_rank == 0
 
         with self._load_table_lock:
-            min_load_local_rank = int(torch.argmin(self._load_table).item())
+            load_table = self._load_table.clone()
 
+        weight = load_table.sum(dim=0, keepdim=True) / load_table
+        weight = torch.softmax(weight, dim=0)
+        min_load_local_rank = int(torch.multinomial(weight, 1).item())
         min_load_global_rank = min_load_local_rank + \
             self._partition_id*self._local_world_size
 

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -348,10 +348,15 @@ class DistributedTemporalSampler:
         # update load table
         load_table[min_load_local_rank] += len(target_vertices)
 
-        # send sampling task to the rank
-        ret = rpc.rpc_sync("worker{}".format(min_load_global_rank),
-                           graph_services.sample_layer_local,
-                           args=(target_vertices, timestamps, layer, snapshot))
+        if min_load_global_rank == self._rank:
+            # sample locally
+            ret = graph_services.sample_layer_local(
+                target_vertices, timestamps, layer, snapshot)
+        else:
+            # send sampling task to the rank
+            ret = rpc.rpc_sync("worker{}".format(min_load_global_rank),
+                               graph_services.sample_layer_local,
+                               args=(target_vertices, timestamps, layer, snapshot))
 
         # update load table
         self._load_table[min_load_local_rank] -= len(target_vertices)

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -57,7 +57,7 @@ class DistributedTemporalSampler:
         self._sampling_time = torch.zeros(self._num_partitions)
         if dynamic_scheduling:
             self._sampling_weight_matrix = np.ones(
-                self._num_partitions, self._local_world_size)
+                (self._num_partitions, self._local_world_size))
 
     def _sampling_loop(self):
         while True:

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -341,7 +341,9 @@ class DistributedTemporalSampler:
         load_table = self._load_table
 
         # find which rank to sample
-        min_load_local_rank = int(torch.multinomial(load_table, 1).item())
+        weight = load_table.sum(dim=0, keepdim=True) / load_table
+        weight = torch.softmax(weight, dim=0)
+        min_load_local_rank = int(torch.multinomial(weight, 1).item())
         min_load_global_rank = min_load_local_rank + \
             self._partition_id*self._local_world_size
 

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -58,7 +58,7 @@ class DistributedTemporalSampler:
 
         if self._dynamic_scheduling:
             if self._local_rank == 0:
-                self._load_table = torch.zeros(self._local_world_size)
+                self._load_table = torch.zeros(self._local_world_size) + 1e-4
 
     def _sampling_loop(self):
         while True:

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -58,7 +58,7 @@ class DistributedTemporalSampler:
         if dynamic_scheduling:
             self._beta = 0.5
             self._sampling_weight_matrix = torch.ones(
-                self._num_partitions, self._local_world_size)
+                self._num_partitions, self._local_world_size) / self._local_world_size
 
     def _sampling_loop(self):
         while True:

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -99,11 +99,11 @@ class DistributedTemporalSampler:
             sampling_time) for _ in range(self._num_partitions * self._local_world_size)]
         torch.distributed.all_gather(all_sampling_time, sampling_time)
 
-        # merge by local machine
+        # merge by partition
         all_sampling_time = torch.stack(all_sampling_time)
         all_sampling_time = all_sampling_time.reshape(
             self._num_partitions, self._local_world_size, self._num_partitions)
-        all_sampling_time = all_sampling_time.sum(dim=1)
+        all_sampling_time = all_sampling_time.sum(dim=2)
 
         return all_sampling_time
 

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -103,7 +103,7 @@ class DistributedTemporalSampler:
         all_sampling_time = torch.stack(all_sampling_time)
         all_sampling_time = all_sampling_time.reshape(
             self._num_partitions, self._local_world_size, self._num_partitions)
-        all_sampling_time = all_sampling_time.sum(dim=2)
+        all_sampling_time = all_sampling_time.mean(dim=2)
 
         return all_sampling_time
 

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -341,15 +341,12 @@ class DistributedTemporalSampler:
         load_table = self._load_table
 
         # find which rank to sample
-        min_load_local_rank = load_table.argmin()
+        min_load_local_rank = int(torch.multinomial(load_table, 1).item())
         min_load_global_rank = min_load_local_rank + \
             self._partition_id*self._local_world_size
 
         # update load table
         load = len(target_vertices)
-        if min_load_global_rank == self._rank:
-            load *= 2
-
         load_table[min_load_local_rank] += load
 
         if min_load_global_rank == self._rank:

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -350,9 +350,6 @@ class DistributedTemporalSampler:
 
         # update load table
         load = len(target_vertices)
-        if min_load_global_rank != self._rank:
-            load *= 1.2
-
         with self._load_table_lock:
             self._load_table[min_load_local_rank] += load
 

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -122,7 +122,7 @@ class DistributedTemporalSampler:
             self._sampling_weight_matrix += (1 - self._beta) * weight
 
         # reset
-        self._sampling_time.zero_()
+        # self._sampling_time.zero_()
 
         return result
 

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -58,7 +58,7 @@ class DistributedTemporalSampler:
 
         if self._dynamic_scheduling:
             if self._local_rank == 0:
-                self._load_table = torch.zeros(self._local_world_size) + 1e-4
+                self._load_table = torch.ones(self._local_world_size)
 
     def _sampling_loop(self):
         while True:

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -347,7 +347,7 @@ class DistributedTemporalSampler:
 
         # update load table
         load = len(target_vertices)
-        if min_load_global_rank != self._rank:
+        if min_load_global_rank == self._rank:
             load *= 2
 
         load_table[min_load_local_rank] += load

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -118,6 +118,8 @@ class DistributedTemporalSampler:
             weight = weight.sum(dim=1, keepdim=True) / weight
             weight = torch.softmax(weight, dim=1)
             self._sampling_weight_matrix = weight
+            if self._local_rank == 0:
+                print(f"weight: {weight}")
 
         return all_sampling_time
 

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -113,7 +113,8 @@ class DistributedTemporalSampler:
         all_sampling_time = all_sampling_time.mean(dim=2)
 
         if self._dynamic_scheduling:
-            self._sampling_weight_matrix = torch.softmax(1.0 / all_sampling_time, dim=1)
+            # self._sampling_weight_matrix = 1.0 / all_sampling_time
+            pass
 
         return all_sampling_time
 

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -56,7 +56,7 @@ class DistributedTemporalSampler:
         # profiling
         self._sampling_time = torch.zeros(self._num_partitions)
         if dynamic_scheduling:
-            self._beta = 0.1
+            self._gen = torch.Generator()
             self._sampling_weight_matrix = torch.ones(
                 self._num_partitions, self._local_world_size)
 
@@ -117,8 +117,10 @@ class DistributedTemporalSampler:
             weight = all_sampling_time.clone()
             weight = weight.sum(dim=1, keepdim=True) / weight
             weight = torch.softmax(weight, dim=1)
-            self._sampling_weight_matrix *= self._beta
-            self._sampling_weight_matrix += (1 - self._beta) * weight
+            self._sampling_weight_matrix = weight
+        
+        # reset
+        self._sampling_time.zero_()
 
         return all_sampling_time
 

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -56,8 +56,10 @@ class DistributedTemporalSampler:
         # profiling
         self._sampling_time = torch.zeros(self._num_partitions)
         if dynamic_scheduling:
-            self._sampling_weight_matrix = np.ones(
-                (self._num_partitions, self._local_world_size))
+            x = np.ones((self._num_partitions, self._local_world_size))
+            # softmax
+            self._sampling_weight_matrix = np.exp(
+                x) / np.sum(np.exp(x), axis=1, keepdims=True)
 
     def _sampling_loop(self):
         while True:

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -176,7 +176,7 @@ class DistributedTemporalSampler:
             partition_timestamps = torch.from_numpy(
                 timestamps[partition_mask]).contiguous()
 
-            if self._parition_id = partition_id:
+            if self._partition_id == partition_id:
                 logging.debug(
                     "worker %d call local sample_layer_local", self._rank)
                 futures.append(graph_services.sample_layer_local(partition_vertices, partition_timestamps,

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -349,7 +349,8 @@ class DistributedTemporalSampler:
                 self._partition_id*self._local_world_size
 
             # update load table
-            load = len(target_vertices)
+            out_degree = self._dgraph.out_degree(target_vertices.numpy())
+            load = np.sum(out_degree)
             self._load_table[min_load_local_rank] += load
 
         if min_load_global_rank == self._rank:

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -113,7 +113,7 @@ class DistributedTemporalSampler:
         all_sampling_time = all_sampling_time.mean(dim=2)
 
         if self._dynamic_scheduling:
-            self._sampling_weight_matrix = 1.0 / all_sampling_time
+            self._sampling_weight_matrix = torch.softmax(1.0 / all_sampling_time, dim=1)
 
         return all_sampling_time
 

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -44,6 +44,11 @@ class DistributedTemporalSampler:
         self._partition_table = self._dgraph.get_partition_table()
         self._num_partitions = self._dgraph.num_partitions()
 
+        local_group_rank = self._rank // self._local_world_size
+        local_ranks = list(range(local_group_rank * self._local_world_size,
+                                 (local_group_rank + 1) * self._local_world_size))
+        self._local_group = torch.distributed.new_group(local_ranks)
+
         self._handle_manager = HandleManager()
         self._sampling_thread = threading.Thread(target=self._sampling_loop)
         self._sampling_task_queue = Queue()
@@ -95,10 +100,9 @@ class DistributedTemporalSampler:
         """
         sampling_time = self._sampling_time.clone()
         # local group per machine
-        local_group_rank = self._rank // self._local_world_size
-        local_group = torch.distributed.new_group(range(local_group_rank * self._local_world_size,
-                                                        (local_group_rank + 1) * self._local_world_size))
-        torch.distributed.all_reduce(sampling_time, group=local_group)
+        print("enter all reduce, local group: ", self._local_group)
+        torch.distributed.all_reduce(sampling_time, group=self._local_group)
+        print("Rank %d: sampling time: %s" % (self._rank, sampling_time))
         # gather all
         all_sampling_time = [torch.zeros_like(
             sampling_time) for _ in range(self._num_partitions)]

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -118,10 +118,9 @@ class DistributedTemporalSampler:
             weight = weight.sum(dim=1, keepdim=True) / weight
             weight = torch.softmax(weight, dim=1)
             self._sampling_weight_matrix = weight
-            if self._local_rank == 0:
-                print(f"weight: {weight}")
         
-        self._sampling_time.zero_()
+        # exponential decay
+        self._sampling_time *= 0.9
 
         return all_sampling_time
 

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -100,10 +100,10 @@ class DistributedTemporalSampler:
                                                         (local_group_rank + 1) * self._local_world_size))
         torch.distributed.all_reduce(sampling_time, group=local_group)
         # gather all
-        all_sampling_time = torch.zeros(
-            self._num_partitions, self._num_partitions)
+        all_sampling_time = [torch.zeros_like(
+            sampling_time) for _ in range(self._num_partitions)]
         torch.distributed.all_gather(all_sampling_time, sampling_time)
-        return all_sampling_time
+        return torch.stack(all_sampling_time)
 
     def sample(self, target_vertices: np.ndarray, timestamps: np.ndarray) -> List[List[DGLBlock]]:
         """

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -346,7 +346,11 @@ class DistributedTemporalSampler:
             self._partition_id*self._local_world_size
 
         # update load table
-        load_table[min_load_local_rank] += len(target_vertices)
+        load = len(target_vertices)
+        if min_load_global_rank != self._rank:
+            load *= 2
+
+        load_table[min_load_local_rank] += load
 
         if min_load_global_rank == self._rank:
             # sample locally
@@ -359,5 +363,5 @@ class DistributedTemporalSampler:
                                args=(target_vertices, timestamps, layer, snapshot))
 
         # update load table
-        self._load_table[min_load_local_rank] -= len(target_vertices)
+        self._load_table[min_load_local_rank] -= load
         return ret

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -120,6 +120,8 @@ class DistributedTemporalSampler:
             weight = torch.softmax(weight, dim=1)
             self._sampling_weight_matrix *= self._beta
             self._sampling_weight_matrix += (1 - self._beta) * weight
+            if self._rank == 0:
+                print(self._sampling_weight_matrix)
 
         # reset
         self._sampling_time.zero_()

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -56,7 +56,7 @@ class DistributedTemporalSampler:
         # profiling
         self._sampling_time = torch.zeros(self._num_partitions)
         if dynamic_scheduling:
-            self._beta = 0.5
+            self._beta = 0
             self._sampling_weight_matrix = torch.ones(
                 self._num_partitions, self._local_world_size) / self._local_world_size
 

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -56,7 +56,7 @@ class DistributedTemporalSampler:
         # profiling
         self._sampling_time = torch.zeros(1)
         if dynamic_scheduling:
-            self._beta = 0
+            self._beta = 0.9
             self._sampling_weight_matrix = torch.ones(
                 self._num_partitions, self._local_world_size) / self._local_world_size
 

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -343,9 +343,7 @@ class DistributedTemporalSampler:
             load_table = self._load_table.clone()
 
         # find which rank to sample
-        weight = load_table.sum(dim=0, keepdim=True) / load_table
-        weight = torch.softmax(weight, dim=0)
-        min_load_local_rank = int(torch.multinomial(weight, 1).item())
+        min_load_local_rank = int(torch.argmin(load_table).item())
         min_load_global_rank = min_load_local_rank + \
             self._partition_id*self._local_world_size
 

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -112,7 +112,7 @@ class DistributedTemporalSampler:
         for i in range(self._num_partitions):
             for j in range(self._local_world_size):
                 for k in range(self._num_partitions):
-                    result[i][j] = all_sampling_time[k * self._local_world_size + j][i]
+                    result[i][j] += all_sampling_time[k * self._local_world_size + j][i]
                 
         if self._dynamic_scheduling:
             weight = result.clone()

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -343,7 +343,7 @@ class DistributedTemporalSampler:
             load_table = self._load_table.clone()
 
         # find which rank to sample
-        weight = load_table.sum(dim=1, keepdim=True) / load_table
+        weight = load_table.sum(dim=0, keepdim=True) / load_table
         weight = torch.softmax(weight, dim=0)
         min_load_local_rank = int(torch.multinomial(weight, 1).item())
         min_load_global_rank = min_load_local_rank + \

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -56,7 +56,7 @@ class DistributedTemporalSampler:
         # profiling
         self._sampling_time = torch.zeros(self._num_partitions)
         if dynamic_scheduling:
-            self._gen = torch.Generator()
+            self._beta = 0.1
             self._sampling_weight_matrix = torch.ones(
                 self._num_partitions, self._local_world_size)
 
@@ -117,10 +117,8 @@ class DistributedTemporalSampler:
             weight = all_sampling_time.clone()
             weight = weight.sum(dim=1, keepdim=True) / weight
             weight = torch.softmax(weight, dim=1)
-            self._sampling_weight_matrix = weight
-        
-        # exponential decay
-        self._sampling_time *= 0.9
+            self._sampling_weight_matrix *= self._beta
+            self._sampling_weight_matrix += (1 - self._beta) * weight
 
         return all_sampling_time
 

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -122,7 +122,7 @@ class DistributedTemporalSampler:
             self._sampling_weight_matrix += (1 - self._beta) * weight
 
         # reset
-        # self._sampling_time.zero_()
+        self._sampling_time.zero_()
 
         return result
 

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -115,8 +115,7 @@ class DistributedTemporalSampler:
 
         if self._dynamic_scheduling:
             weight = all_sampling_time.clone()
-            # mean and softmax
-            weight = weight - weight.mean(dim=1)
+            weight = weight.sum(dim=1, keepdim=True) / weight
             weight = torch.softmax(weight, dim=1)
             self._sampling_weight_matrix = weight
 

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -325,7 +325,7 @@ class DistributedTemporalSampler:
             target_vertices, timestamps, layer, snapshot, False)
         return ret
 
-    def dispatch_sampling_task(self, target_vertices: np.ndarray, timestamps: np.ndarray,
+    def dispatch_sampling_task(self, target_vertices: torch.Tensor, timestamps: torch.Tensor,
                                layer: int, snapshot: int):
         """
         Dispatch sampling task to GPUs based on load table
@@ -350,8 +350,8 @@ class DistributedTemporalSampler:
 
         # send sampling task to the rank
         ret = rpc.rpc_sync("worker{}".format(min_load_global_rank),
-                            graph_services.sample_layer_local,
-                            args=(target_vertices, timestamps, layer, snapshot))
+                           graph_services.sample_layer_local,
+                           args=(target_vertices, timestamps, layer, snapshot))
 
         # update load table
         self._load_table[min_load_local_rank] -= len(target_vertices)

--- a/gnnflow/distributed/dist_sampler.py
+++ b/gnnflow/distributed/dist_sampler.py
@@ -340,17 +340,15 @@ class DistributedTemporalSampler:
         assert self._local_rank == 0
 
         with self._load_table_lock:
-            load_table = self._load_table.clone()
+            min_load_local_rank = int(torch.argmin(self._load_table).item())
 
-        # find which rank to sample
-        min_load_local_rank = int(torch.argmin(load_table).item())
         min_load_global_rank = min_load_local_rank + \
             self._partition_id*self._local_world_size
 
         # update load table
         load = len(target_vertices)
         with self._load_table_lock:
-            load_table[min_load_local_rank] += load
+            self._load_table[min_load_local_rank] += load
 
         if min_load_global_rank == self._rank:
             # sample locally

--- a/gnnflow/distributed/graph_services.py
+++ b/gnnflow/distributed/graph_services.py
@@ -248,7 +248,7 @@ def sample_layer_local_proxy(target_vertices: torch.Tensor, timestamps: torch.Te
     """
     dsampler = get_dsampler()
     return dsampler.dispatch_sampling_task(
-        target_vertices.numpy(), timestamps.numpy(), layer, snapshot)
+        target_vertices, timestamps, layer, snapshot)
 
 
 def push_tensors(keys: torch.Tensor, tensors: torch.Tensor, mode: str):

--- a/gnnflow/distributed/graph_services.py
+++ b/gnnflow/distributed/graph_services.py
@@ -232,6 +232,26 @@ def sample_layer_local(target_vertices: torch.Tensor, timestamps: torch.Tensor,
     return ret
 
 
+def sample_layer_local_proxy(target_vertices: torch.Tensor, timestamps: torch.Tensor,
+                             layer: int, snapshot: int):
+    """
+    Dispatch the sample_layer_local request to the correct rank.
+
+    Args:
+        target_vertices (torch.Tensor): The target vertices.
+        timestamps (torch.Tensor): The timestamps.
+        layer (int): The layer.
+        snapshot (int): The snapshot.
+
+    Returns:
+        RemoteReference of SamplingResultTorch: The remote reference of the sampling result.
+    """
+    dsampler = get_dsampler()
+    rref = dsampler.dispatch_sampling_task(
+        target_vertices.numpy(), timestamps.numpy(), layer, snapshot)
+    return rref
+
+
 def push_tensors(keys: torch.Tensor, tensors: torch.Tensor, mode: str):
     """
     Push tensors to the remote workers for KVStore servers.

--- a/gnnflow/distributed/graph_services.py
+++ b/gnnflow/distributed/graph_services.py
@@ -233,7 +233,7 @@ def sample_layer_local(target_vertices: torch.Tensor, timestamps: torch.Tensor,
 
 
 def sample_layer_local_proxy(target_vertices: torch.Tensor, timestamps: torch.Tensor,
-                             layer: int, snapshot: int):
+                             layer: int, snapshot: int) -> SamplingResultTorch:
     """
     Dispatch the sample_layer_local request to the correct rank.
 
@@ -244,12 +244,11 @@ def sample_layer_local_proxy(target_vertices: torch.Tensor, timestamps: torch.Te
         snapshot (int): The snapshot.
 
     Returns:
-        RemoteReference of SamplingResultTorch: The remote reference of the sampling result.
+        torch.Tensor: The temporal neighbors of the vertex.
     """
     dsampler = get_dsampler()
-    rref = dsampler.dispatch_sampling_task(
+    return dsampler.dispatch_sampling_task(
         target_vertices.numpy(), timestamps.numpy(), layer, snapshot)
-    return rref
 
 
 def push_tensors(keys: torch.Tensor, tensors: torch.Tensor, mode: str):

--- a/gnnflow/distributed/graph_services.py
+++ b/gnnflow/distributed/graph_services.py
@@ -56,7 +56,7 @@ def get_dsampler() -> DistributedTemporalSampler:
     return DSAMPLER
 
 
-def set_dsampler(sampler: TemporalSampler):
+def set_dsampler(sampler: TemporalSampler, dynamic_scheduling: bool = False):
     """
     Set the distributed temporal sampler.
 
@@ -65,7 +65,7 @@ def set_dsampler(sampler: TemporalSampler):
     """
     global DSAMPLER
     dgraph = get_dgraph()
-    DSAMPLER = DistributedTemporalSampler(sampler, dgraph)
+    DSAMPLER = DistributedTemporalSampler(sampler, dgraph, dynamic_scheduling)
 
 
 def get_kvstore_server() -> KVStoreServer:

--- a/scripts/offline_edge_prediction_multi_node_kvstore.py
+++ b/scripts/offline_edge_prediction_multi_node_kvstore.py
@@ -373,7 +373,7 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
 
                 if args.rank == 0:
                     logging.info('Epoch {:d}/{:d} | Iter {:d}/{:d} | Throughput {:.2f} samples/s | Loss {:.4f} | Cache node ratio {:.4f} | Cache edge ratio {:.4f} | sampling time CV {:.4f}'.format(e + 1, args.epoch, i + 1, int(len(
-                        train_loader)/args.world_size), total_samples * args.world_size / (time.time() - epoch_time_start), total_loss / (i + 1), cache_node_ratio_sum / (i + 1), cache_edge_ratio_sum / (i + 1), cv_sampling_time))
+                        train_loader)/args.world_size), total_samples * args.world_size / (time.time() - epoch_time_start), total_loss / (i + 1), cache_node_ratio_sum / (i + 1), cache_edge_ratio_sum / (i + 1), cv_sampling_time / ((i+1) / args.print_freq)))
 
         epoch_time = time.time() - epoch_time_start
         epoch_time_sum += epoch_time
@@ -407,7 +407,7 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
 
         if args.rank == 0:
             logging.info("Epoch {:d}/{:d} | Validation ap {:.4f} | Validation auc {:.4f} | Train time {:.2f} s | Validation time {:.2f} s | Train Throughput {:.2f} samples/s | Cache node ratio {:.4f} | Cache edge ratio {:.4f} | sampling time CV {:.4f}".format(
-                e + 1, args.epoch, val_ap, val_auc, epoch_time, val_time, total_samples * args.world_size / epoch_time, cache_node_ratio_sum / (i + 1), cache_edge_ratio_sum / (i + 1), cv_sampling_time))
+                e + 1, args.epoch, val_ap, val_auc, epoch_time, val_time, total_samples * args.world_size / epoch_time, cache_node_ratio_sum / (i + 1), cache_edge_ratio_sum / (i + 1), cv_sampling_time / ((i+1) / args.print_freq)))
 
         if args.rank == 0 and e > 1 and val_ap > best_ap:
             best_e = e + 1

--- a/scripts/offline_edge_prediction_multi_node_kvstore.py
+++ b/scripts/offline_edge_prediction_multi_node_kvstore.py
@@ -371,7 +371,7 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
                         train_loader)/args.world_size), total_samples * args.world_size / (time.time() - epoch_time_start), total_loss / (i + 1), cache_node_ratio_sum / (i + 1), cache_edge_ratio_sum / (i + 1)))
 
                     if args.distributed:
-                        logging.info('Sampling time: ', all_sampling_time)
+                        print('Sampling time: ', all_sampling_time)
 
 
         epoch_time = time.time() - epoch_time_start
@@ -406,7 +406,7 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
                 e + 1, args.epoch, val_ap, val_auc, epoch_time, val_time, total_samples * args.world_size / epoch_time, cache_node_ratio_sum / (i + 1), cache_edge_ratio_sum / (i + 1)))
 
             if args.distributed:
-                logging.info('Sampling time: ', all_sampling_time)
+                print('Sampling time: ', all_sampling_time)
 
         if args.rank == 0 and e > 1 and val_ap > best_ap:
             best_e = e + 1

--- a/scripts/offline_edge_prediction_multi_node_kvstore.py
+++ b/scripts/offline_edge_prediction_multi_node_kvstore.py
@@ -69,6 +69,8 @@ parser.add_argument("--ingestion-batch-size", type=int, default=1000,
                     help="ingestion batch size")
 parser.add_argument("--partition-strategy", type=str, default="roundrobin",
                     help="partition strategy for distributed training")
+parser.add_argument("--dynamic-scheduling", action="store_true",
+                    help="whether to use dynamic scheduling")
 
 # dataset
 parser.add_argument("--chunks", help="num of dataset chunks",
@@ -256,7 +258,7 @@ def main():
     if args.distributed:
         assert isinstance(dgraph, DistributedDynamicGraph)
         sampler = TemporalSampler(dgraph._dgraph, **model_config)
-        graph_services.set_dsampler(sampler)
+        graph_services.set_dsampler(sampler, args.dynamic_scheduling)
         sampler = graph_services.get_dsampler()
     else:
         assert isinstance(dgraph, DynamicGraph)
@@ -372,7 +374,6 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
 
                     if args.distributed:
                         print('Sampling time: ', all_sampling_time)
-
 
         epoch_time = time.time() - epoch_time_start
         epoch_time_sum += epoch_time

--- a/scripts/offline_edge_prediction_multi_node_kvstore.py
+++ b/scripts/offline_edge_prediction_multi_node_kvstore.py
@@ -320,7 +320,7 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
     best_e = 0
     epoch_time_sum = 0
     early_stopper = EarlyStopMonitor()
-    logging.info('Start training...')
+    logging.info('Start training... distributed: {}'.format(args.distributed))
     for e in range(args.epoch):
         model.train()
         # TODO: now reset do nothing when using distributed
@@ -371,7 +371,7 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
                         train_loader)/args.world_size), total_samples * args.world_size / (time.time() - epoch_time_start), total_loss / (i + 1), cache_node_ratio_sum / (i + 1), cache_edge_ratio_sum / (i + 1)))
 
                     if args.distributed:
-                        logging.info('Sampling time: {}'.format(all_sampling_time))
+                        print('Sampling time: ', all_sampling_time)
 
         epoch_time = time.time() - epoch_time_start
         epoch_time_sum += epoch_time

--- a/scripts/offline_edge_prediction_multi_node_kvstore.py
+++ b/scripts/offline_edge_prediction_multi_node_kvstore.py
@@ -94,8 +94,6 @@ def set_seed(seed):
     torch.cuda.manual_seed_all(seed)
 
 
-
-
 def evaluate(dataloader, sampler, model, criterion, cache, device):
     model.eval()
     val_losses = list()
@@ -357,6 +355,7 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
             cache_node_ratio_sum += cache.cache_node_ratio
             total_samples += len(target_nodes)
 
+            std_sampling_time = 0
             if (i+1) % args.print_freq == 0:
                 if args.distributed:
                     metrics = torch.tensor([total_loss, cache_edge_ratio_sum,
@@ -368,13 +367,11 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
                         total_samples = metrics.tolist()
 
                     all_sampling_time = sampler.get_sampling_time()
+                    std_sampling_time = all_sampling_time.std(dim=0).mean()
 
                 if args.rank == 0:
-                    logging.info('Epoch {:d}/{:d} | Iter {:d}/{:d} | Throughput {:.2f} samples/s | Loss {:.4f} | Cache node ratio {:.4f} | Cache edge ratio {:.4f}'.format(e + 1, args.epoch, i + 1, int(len(
-                        train_loader)/args.world_size), total_samples * args.world_size / (time.time() - epoch_time_start), total_loss / (i + 1), cache_node_ratio_sum / (i + 1), cache_edge_ratio_sum / (i + 1)))
-
-                    if args.distributed:
-                        print('Sampling time: ', all_sampling_time)
+                    logging.info('Epoch {:d}/{:d} | Iter {:d}/{:d} | Throughput {:.2f} samples/s | Loss {:.4f} | Cache node ratio {:.4f} | Cache edge ratio {:.4f} | std sampling time {:.4f}'.format(e + 1, args.epoch, i + 1, int(len(
+                        train_loader)/args.world_size), total_samples * args.world_size / (time.time() - epoch_time_start), total_loss / (i + 1), cache_node_ratio_sum / (i + 1), cache_edge_ratio_sum / (i + 1), std_sampling_time))
 
         epoch_time = time.time() - epoch_time_start
         epoch_time_sum += epoch_time
@@ -393,6 +390,7 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
         val_end = time.time()
         val_time = val_end - val_start
 
+        std_sampling_time = 0
         if args.distributed:
             metrics = torch.tensor([val_ap, val_auc, cache_edge_ratio_sum,
                                     cache_node_ratio_sum, total_samples], device=device)
@@ -402,13 +400,11 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
                 total_samples = metrics.tolist()
 
             all_sampling_time = sampler.get_sampling_time()
+            std_sampling_time = all_sampling_time.std(dim=0).mean()
 
         if args.rank == 0:
-            logging.info("Epoch {:d}/{:d} | Validation ap {:.4f} | Validation auc {:.4f} | Train time {:.2f} s | Validation time {:.2f} s | Train Throughput {:.2f} samples/s | Cache node ratio {:.4f} | Cache edge ratio {:.4f}".format(
-                e + 1, args.epoch, val_ap, val_auc, epoch_time, val_time, total_samples * args.world_size / epoch_time, cache_node_ratio_sum / (i + 1), cache_edge_ratio_sum / (i + 1)))
-
-            if args.distributed:
-                print('Sampling time: ', all_sampling_time)
+            logging.info("Epoch {:d}/{:d} | Validation ap {:.4f} | Validation auc {:.4f} | Train time {:.2f} s | Validation time {:.2f} s | Train Throughput {:.2f} samples/s | Cache node ratio {:.4f} | Cache edge ratio {:.4f} | std sampling time {:.4f}".format(
+                e + 1, args.epoch, val_ap, val_auc, epoch_time, val_time, total_samples * args.world_size / epoch_time, cache_node_ratio_sum / (i + 1), cache_edge_ratio_sum / (i + 1), std_sampling_time))
 
         if args.rank == 0 and e > 1 and val_ap > best_ap:
             best_e = e + 1

--- a/scripts/offline_edge_prediction_multi_node_kvstore.py
+++ b/scripts/offline_edge_prediction_multi_node_kvstore.py
@@ -401,6 +401,9 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
                 total_samples = metrics.tolist()
 
             all_sampling_time = sampler.get_sampling_time()
+            if args.rank == 0:
+                print(all_sampling_time)
+
             std = all_sampling_time.std(dim=1).mean()
             mean = all_sampling_time.mean(dim=1).mean()
             cv_sampling_time = std / mean

--- a/scripts/offline_edge_prediction_multi_node_kvstore.py
+++ b/scripts/offline_edge_prediction_multi_node_kvstore.py
@@ -369,11 +369,11 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
                     all_sampling_time = sampler.get_sampling_time()
                     std = all_sampling_time.std(dim=1).mean()
                     mean = all_sampling_time.mean(dim=1).mean()
-                    cv_sampling_time = std / mean
+                    cv_sampling_time += std / mean
 
                 if args.rank == 0:
-                    logging.info('Epoch {:d}/{:d} | Iter {:d}/{:d} | Throughput {:.2f} samples/s | Loss {:.4f} | Cache node ratio {:.4f} | Cache edge ratio {:.4f} | sampling time CV {:.4f}'.format(e + 1, args.epoch, i + 1, int(len(
-                        train_loader)/args.world_size), total_samples * args.world_size / (time.time() - epoch_time_start), total_loss / (i + 1), cache_node_ratio_sum / (i + 1), cache_edge_ratio_sum / (i + 1), cv_sampling_time))
+                    logging.info('Epoch {:d}/{:d} | Iter {:d}/{:d} | Throughput {:.2f} samples/s | Loss {:.4f} | Cache node ratio {:.4f} | Cache edge ratio {:.4f} | avg sampling time CV {:.4f}'.format(e + 1, args.epoch, i + 1, int(len(
+                        train_loader)/args.world_size), total_samples * args.world_size / (time.time() - epoch_time_start), total_loss / (i + 1), cache_node_ratio_sum / (i + 1), cache_edge_ratio_sum / (i + 1), cv_sampling_time / ((i+1)/args.print_freq)))
 
         epoch_time = time.time() - epoch_time_start
         epoch_time_sum += epoch_time
@@ -406,11 +406,11 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
 
             std = all_sampling_time.std(dim=1).mean()
             mean = all_sampling_time.mean(dim=1).mean()
-            cv_sampling_time = std / mean
+            cv_sampling_time += std / mean
 
         if args.rank == 0:
             logging.info("Epoch {:d}/{:d} | Validation ap {:.4f} | Validation auc {:.4f} | Train time {:.2f} s | Validation time {:.2f} s | Train Throughput {:.2f} samples/s | Cache node ratio {:.4f} | Cache edge ratio {:.4f} | sampling time CV {:.4f}".format(
-                e + 1, args.epoch, val_ap, val_auc, epoch_time, val_time, total_samples * args.world_size / epoch_time, cache_node_ratio_sum / (i + 1), cache_edge_ratio_sum / (i + 1), cv_sampling_time))
+                e + 1, args.epoch, val_ap, val_auc, epoch_time, val_time, total_samples * args.world_size / epoch_time, cache_node_ratio_sum / (i + 1), cache_edge_ratio_sum / (i + 1), cv_sampling_time / ((i+1)/args.print_freq)))
 
         if args.rank == 0 and e > 1 and val_ap > best_ap:
             best_e = e + 1

--- a/scripts/offline_edge_prediction_multi_node_kvstore.py
+++ b/scripts/offline_edge_prediction_multi_node_kvstore.py
@@ -371,7 +371,8 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
                         train_loader)/args.world_size), total_samples * args.world_size / (time.time() - epoch_time_start), total_loss / (i + 1), cache_node_ratio_sum / (i + 1), cache_edge_ratio_sum / (i + 1)))
 
                     if args.distributed:
-                        print('Sampling time: ', all_sampling_time)
+                        logging.info('Sampling time: ', all_sampling_time)
+
 
         epoch_time = time.time() - epoch_time_start
         epoch_time_sum += epoch_time
@@ -398,9 +399,14 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
             val_ap, val_auc, cache_edge_ratio_sum, cache_node_ratio_sum, \
                 total_samples = metrics.tolist()
 
+            all_sampling_time = sampler.get_sampling_time()
+
         if args.rank == 0:
             logging.info("Epoch {:d}/{:d} | Validation ap {:.4f} | Validation auc {:.4f} | Train time {:.2f} s | Validation time {:.2f} s | Train Throughput {:.2f} samples/s | Cache node ratio {:.4f} | Cache edge ratio {:.4f}".format(
                 e + 1, args.epoch, val_ap, val_auc, epoch_time, val_time, total_samples * args.world_size / epoch_time, cache_node_ratio_sum / (i + 1), cache_edge_ratio_sum / (i + 1)))
+
+            if args.distributed:
+                logging.info('Sampling time: ', all_sampling_time)
 
         if args.rank == 0 and e > 1 and val_ap > best_ap:
             best_e = e + 1

--- a/scripts/offline_edge_prediction_multi_node_kvstore.py
+++ b/scripts/offline_edge_prediction_multi_node_kvstore.py
@@ -367,8 +367,8 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
                         total_samples = metrics.tolist()
 
                     all_sampling_time = sampler.get_sampling_time()
-                    std = all_sampling_time.std(dim=0).mean()
-                    mean = all_sampling_time.mean(dim=0).mean()
+                    std = all_sampling_time.std(dim=1).mean()
+                    mean = all_sampling_time.mean(dim=1).mean()
                     cv_sampling_time = std / mean
 
                 if args.rank == 0:
@@ -401,8 +401,8 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
                 total_samples = metrics.tolist()
 
             all_sampling_time = sampler.get_sampling_time()
-            std = all_sampling_time.std(dim=0).mean()
-            mean = all_sampling_time.mean(dim=0).mean()
+            std = all_sampling_time.std(dim=1).mean()
+            mean = all_sampling_time.mean(dim=1).mean()
             cv_sampling_time = std / mean
 
         if args.rank == 0:

--- a/scripts/offline_edge_prediction_multi_node_kvstore.py
+++ b/scripts/offline_edge_prediction_multi_node_kvstore.py
@@ -369,11 +369,11 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
                     all_sampling_time = sampler.get_sampling_time()
                     std = all_sampling_time.std(dim=0).mean()
                     mean = all_sampling_time.mean(dim=0).mean()
-                    cv_sampling_time += std / mean
+                    cv_sampling_time = std / mean
 
                 if args.rank == 0:
                     logging.info('Epoch {:d}/{:d} | Iter {:d}/{:d} | Throughput {:.2f} samples/s | Loss {:.4f} | Cache node ratio {:.4f} | Cache edge ratio {:.4f} | sampling time CV {:.4f}'.format(e + 1, args.epoch, i + 1, int(len(
-                        train_loader)/args.world_size), total_samples * args.world_size / (time.time() - epoch_time_start), total_loss / (i + 1), cache_node_ratio_sum / (i + 1), cache_edge_ratio_sum / (i + 1), cv_sampling_time / ((i+1) / args.print_freq)))
+                        train_loader)/args.world_size), total_samples * args.world_size / (time.time() - epoch_time_start), total_loss / (i + 1), cache_node_ratio_sum / (i + 1), cache_edge_ratio_sum / (i + 1), cv_sampling_time))
 
         epoch_time = time.time() - epoch_time_start
         epoch_time_sum += epoch_time
@@ -403,11 +403,11 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
             all_sampling_time = sampler.get_sampling_time()
             std = all_sampling_time.std(dim=0).mean()
             mean = all_sampling_time.mean(dim=0).mean()
-            cv_sampling_time += std / mean
+            cv_sampling_time = std / mean
 
         if args.rank == 0:
             logging.info("Epoch {:d}/{:d} | Validation ap {:.4f} | Validation auc {:.4f} | Train time {:.2f} s | Validation time {:.2f} s | Train Throughput {:.2f} samples/s | Cache node ratio {:.4f} | Cache edge ratio {:.4f} | sampling time CV {:.4f}".format(
-                e + 1, args.epoch, val_ap, val_auc, epoch_time, val_time, total_samples * args.world_size / epoch_time, cache_node_ratio_sum / (i + 1), cache_edge_ratio_sum / (i + 1), cv_sampling_time / ((i+1) / args.print_freq)))
+                e + 1, args.epoch, val_ap, val_auc, epoch_time, val_time, total_samples * args.world_size / epoch_time, cache_node_ratio_sum / (i + 1), cache_edge_ratio_sum / (i + 1), cv_sampling_time))
 
         if args.rank == 0 and e > 1 and val_ap > best_ap:
             best_e = e + 1

--- a/scripts/offline_edge_prediction_multi_node_kvstore.py
+++ b/scripts/offline_edge_prediction_multi_node_kvstore.py
@@ -94,7 +94,6 @@ def set_seed(seed):
     torch.cuda.manual_seed_all(seed)
 
 
-set_seed(args.seed)
 
 
 def evaluate(dataloader, sampler, model, criterion, cache, device):
@@ -147,6 +146,8 @@ def main():
         args.local_world_size = args.world_size = 1
 
     logging.info("rank: {}, world_size: {}".format(args.rank, args.world_size))
+
+    set_seed(args.seed + args.rank)
 
     model_config, data_config = get_default_config(args.model, args.data)
 

--- a/scripts/offline_edge_prediction_multi_node_kvstore.py
+++ b/scripts/offline_edge_prediction_multi_node_kvstore.py
@@ -188,7 +188,6 @@ def main():
         dim_node = 0 if node_feats is None else node_feats.shape[1]
         dim_edge = 0 if edge_feats is None else edge_feats.shape[1]
 
-
     num_nodes = dgraph.num_vertices() + 1
     num_edges = dgraph.num_edges()
 
@@ -365,9 +364,14 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
                     total_loss, cache_edge_ratio_sum, cache_node_ratio_sum, \
                         total_samples = metrics.tolist()
 
+                    all_sampling_time = sampler.get_sampling_time()
+
                 if args.rank == 0:
                     logging.info('Epoch {:d}/{:d} | Iter {:d}/{:d} | Throughput {:.2f} samples/s | Loss {:.4f} | Cache node ratio {:.4f} | Cache edge ratio {:.4f}'.format(e + 1, args.epoch, i + 1, int(len(
                         train_loader)/args.world_size), total_samples * args.world_size / (time.time() - epoch_time_start), total_loss / (i + 1), cache_node_ratio_sum / (i + 1), cache_edge_ratio_sum / (i + 1)))
+
+                    if args.distributed:
+                        logging.info('Sampling time: {}'.format(all_sampling_time))
 
         epoch_time = time.time() - epoch_time_start
         epoch_time_sum += epoch_time

--- a/scripts/run_offline_multi_node_metal.sh
+++ b/scripts/run_offline_multi_node_metal.sh
@@ -31,8 +31,8 @@ cmd="torchrun \
     --rdzv_conf is_host=$IS_HOST \
     offline_edge_prediction_multi_node_kvstore.py --model $MODEL --data $DATA \
     --cache $CACHE --cache-ratio $CACHE_RATIO \
-    --partition --ingestion-batch-size 100000 \
-    --initial-ingestion-batch-size 100000 \
+    --partition --ingestion-batch-size 1000000 \
+    --initial-ingestion-batch-size 1000000 \
     --partition-strategy $PARTITION_STRATEGY \
     --num-workers 8 --chunks $CHUNKS"
 

--- a/scripts/run_offline_multi_node_metal.sh
+++ b/scripts/run_offline_multi_node_metal.sh
@@ -12,7 +12,7 @@ DYNAMIC_SCHEDULING="${7:-false}"
 HOST_NODE_ADDR=172.31.47.50
 HOST_NODE_PORT=29400
 NNODES=2
-NPROC_PER_NODE=4
+NPROC_PER_NODE=8
 
 CURRENT_NODE_IP=$(ip -4 a show dev ${INTERFACE} | grep inet | cut -d " " -f6 | cut -d "/" -f1)
 if [ $CURRENT_NODE_IP = $HOST_NODE_ADDR ]; then

--- a/scripts/run_offline_multi_node_metal.sh
+++ b/scripts/run_offline_multi_node_metal.sh
@@ -7,6 +7,7 @@ CACHE="${3:-LFUCache}"
 CACHE_RATIO="${4:-0.2}" # default 20% of cache
 PARTITION_STRATEGY="${5:-hash}"
 CHUNKS="${6:-1}"
+DYNAMIC_SCHEDULING="${7:-false}"
 
 HOST_NODE_ADDR=172.31.47.50
 HOST_NODE_PORT=29400
@@ -35,6 +36,10 @@ cmd="torchrun \
     --initial-ingestion-batch-size 1000000 \
     --partition-strategy $PARTITION_STRATEGY \
     --num-workers 8 --chunks $CHUNKS"
+
+if [ $DYNAMIC_SCHEDULING = true ]; then
+    cmd="$cmd --dynamic-scheduling"
+fi
 
 rm -rf /dev/shm/rmm_pool_*
 


### PR DESCRIPTION
## Method 

Current scheduling method is **static scheduling** where each remote task is assigned to the worker with the same local rank as the caller.  

We propose **dynamic scheduling** method. The remote requests are sent to the local root. The local root schedules the tasks based on the load factor of GPUs on the machine. 

## Evalution 

4 x 8. TGN on GDELT. one epoch
| method | sampling time CV |  throughput (samples/s) | 
| --- | --- | --- |
| static | 0.0902 | 467587 |
| dynamic | 0.0736 |  436346 |

