### PR TITLE
feat: partition training samples

### DIFF
--- a/gnnflow/distributed/dispatcher.py
+++ b/gnnflow/distributed/dispatcher.py
@@ -137,7 +137,7 @@ class Dispatcher:
                 timestamps = np.concatenate([timestamps, timestamps])
                 eids = np.concatenate([eids, eids])
 
-            src_nodes = torch.from_numpy(src_nodes))
+            src_nodes = torch.from_numpy(src_nodes)
             dst_nodes=torch.from_numpy(dst_nodes)
             timestamps=torch.from_numpy(timestamps)
             eids=torch.from_numpy(eids)

--- a/gnnflow/distributed/dispatcher.py
+++ b/gnnflow/distributed/dispatcher.py
@@ -138,16 +138,16 @@ class Dispatcher:
                 eids = np.concatenate([eids, eids])
 
             src_nodes = torch.from_numpy(src_nodes)
-            dst_nodes=torch.from_numpy(dst_nodes)
-            timestamps=torch.from_numpy(timestamps)
-            eids=torch.from_numpy(eids)
+            dst_nodes = torch.from_numpy(dst_nodes)
+            timestamps = torch.from_numpy(timestamps)
+            eids = torch.from_numpy(eids)
             futures.extend(self.dispatch_edges(src_nodes, dst_nodes,
                                                timestamps, eids, edge_feats,
                                                partition_train_data))
 
             for future in futures:
                 future.wait()
-            futures=[]
+            futures = []
             t.update(len(batch))
 
         t.close()
@@ -160,9 +160,9 @@ class Dispatcher:
         # Broadcast the graph metadata to all the workers.
         for partition_id in range(self._num_partitions):
             for worker_id in range(self._local_world_size):
-                worker_rank=partition_id * self._local_world_size + worker_id
+                worker_rank = partition_id * self._local_world_size + worker_id
                 rpc.rpc_sync("worker%d" % worker_rank, graph_services.set_graph_metadata,
-                             args = (len(self._nodes), self._num_edges, self._max_node, self._num_partitions))
+                             args=(len(self._nodes), self._num_edges, self._max_node, self._num_partitions))
 
     def broadcast_partition_table(self):
         """
@@ -171,9 +171,9 @@ class Dispatcher:
         # Broadcast the partition table to all the workers.
         for partition_id in range(self._num_partitions):
             for worker_id in range(self._local_world_size):
-                worker_rank=partition_id * self._local_world_size + worker_id
+                worker_rank = partition_id * self._local_world_size + worker_id
                 rpc.rpc_sync("worker%d" % worker_rank, graph_services.set_partition_table,
-                             args = (self._partitioner.get_partition_table(), ))
+                             args=(self._partitioner.get_partition_table(), ))
 
     def broadcast_node_edge_dim(self, dim_node, dim_edge):
         """
@@ -182,16 +182,16 @@ class Dispatcher:
         # Broadcast the dim_node/dim_edge to all the workers.
         for partition_id in range(self._num_partitions):
             for worker_id in range(self._local_world_size):
-                worker_rank=partition_id * self._local_world_size + worker_id
+                worker_rank = partition_id * self._local_world_size + worker_id
                 rpc.rpc_sync("worker%d" % worker_rank, graph_services.set_dim_node_edge,
-                             args = (dim_node, dim_edge))
+                             args=(dim_node, dim_edge))
 
     def broadcast_rand_sampler(self, train_rand_sampler, val_rand_sampler, test_rand_sampler):
         for partition_id in range(self._num_partitions):
             for worker_id in range(self._local_world_size):
-                worker_rank=partition_id * self._local_world_size + worker_id
+                worker_rank = partition_id * self._local_world_size + worker_id
                 rpc.rpc_sync("worker%d" % worker_rank, graph_services.set_rand_sampler,
-                             args = (train_rand_sampler, val_rand_sampler, test_rand_sampler))
+                             args=(train_rand_sampler, val_rand_sampler, test_rand_sampler))
 
 
 def get_dispatcher(partition_strategy: Optional[str] = None, num_partitions: Optional[int] = None):
@@ -207,7 +207,7 @@ def get_dispatcher(partition_strategy: Optional[str] = None, num_partitions: Opt
     """
     global dispatcher
     if dispatcher is None:
-        assert partition_strategy is not None and num_partitions is not None,
+        assert partition_strategy is not None and num_partitions is not None, \
             "The dispatcher is not initialized. Please specify the partitioning strategy and the number of partitions."
-        dispatcher=Dispatcher(partition_strategy, num_partitions)
+        dispatcher = Dispatcher(partition_strategy, num_partitions)
     return dispatcher

--- a/gnnflow/distributed/dist_context.py
+++ b/gnnflow/distributed/dist_context.py
@@ -20,7 +20,7 @@ def initialize(rank: int, world_size: int, dataset: pd.DataFrame,
                initial_ingestion_batch_size: int,
                ingestion_batch_size: int, partition_strategy: str,
                num_partitions: int, undirected: bool, data_name: str,
-               dim_memory: int, chunk: int):
+               dim_memory: int, chunk: int, partition_train_data: bool):
     """
     Initialize the distributed environment.
 
@@ -35,6 +35,7 @@ def initialize(rank: int, world_size: int, dataset: pd.DataFrame,
         data_name (str): the dataset name of the dataset for loading features.
         dim_memory (int): the dimension of memory
         chunk (int): the number of chunks of the dataset
+        partition_train_data (bool): whether to partition the train data
     """
     # NB: disable IB according to https://github.com/pytorch/pytorch/issues/86962
     rpc.init_rpc("worker%d" % rank, rank=rank, world_size=world_size,
@@ -68,7 +69,7 @@ def initialize(rank: int, world_size: int, dataset: pd.DataFrame,
                 dispatcher.partition_graph(dataset, initial_ingestion_batch_size,
                                            ingestion_batch_size,
                                            undirected, node_feats, edge_feats,
-                                           dim_memory)
+                                           dim_memory, partition_train_data)
                 del dataset
         else:
             # for those datasets that don't need chunks
@@ -76,7 +77,7 @@ def initialize(rank: int, world_size: int, dataset: pd.DataFrame,
             dispatcher.partition_graph(dataset, initial_ingestion_batch_size,
                                        ingestion_batch_size,
                                        undirected, node_feats, edge_feats,
-                                       dim_memory)
+                                       dim_memory, partition_train_data)
             del dataset
         # deal with unpartitioned nodes
         partition_table = dispatcher._partitioner._partition_table

--- a/gnnflow/distributed/graph_services.py
+++ b/gnnflow/distributed/graph_services.py
@@ -2,6 +2,8 @@ import logging
 import time
 from typing import Tuple
 
+import numpy as np
+import pandas as pd
 import torch
 import torch.distributed
 
@@ -19,6 +21,8 @@ global DIM_EDGE
 global TRAIN_RAND_SAMPLER
 global TEST_RAND_SAMPLER
 global VAL_RAND_SAMPLER
+
+global TRAIN_DATA
 
 
 def get_dgraph() -> DistributedDynamicGraph:
@@ -113,6 +117,51 @@ def add_edges(source_vertices: torch.Tensor, target_vertices: torch.Tensor,
     dgraph.enqueue_add_edges_task(source_vertices.numpy(),
                                   target_vertices.numpy(), timestamps.numpy(), eids.numpy())
     # NB: no need to wait for the task to finish
+
+
+def add_train_data(source_vertices: torch.Tensor, target_vertices: torch.Tensor,
+                   timestamps: torch.Tensor, eids: torch.Tensor):
+    """
+    Add training samples to the memory.
+
+    Args:
+        source_vertices (torch.Tensor): The source vertices of the edges.
+        target_vertices (torch.Tensor): The target vertices of the edges.
+        timestamps (torch.Tensor): The timestamps of the edges.
+        eids (torch.Tensor): The edge IDs of the edges.
+    """
+    global TRAIN_DATA
+
+    if TRAIN_DATA is None:
+        TRAIN_DATA = [
+            source_vertices.numpy(),
+            target_vertices.numpy(),
+            timestamps.numpy(),
+            eids.numpy()
+        ]
+    else:
+        TRAIN_DATA[0] = np.concatenate((TRAIN_DATA[0], source_vertices.numpy()))
+        TRAIN_DATA[1] = np.concatenate((TRAIN_DATA[1], target_vertices.numpy()))
+        TRAIN_DATA[2] = np.concatenate((TRAIN_DATA[2], timestamps.numpy()))
+        TRAIN_DATA[3] = np.concatenate((TRAIN_DATA[3], eids.numpy()))
+
+
+def get_train_data() -> pd.DataFrame:
+    """
+    Get the training data.
+
+    Returns:
+        pd.DataFrame: The training data.
+    """
+    global TRAIN_DATA
+    if TRAIN_DATA is None:
+        raise RuntimeError("The training data has not been initialized.")
+    return pd.DataFrame({
+        "src": TRAIN_DATA[0],
+        "dst": TRAIN_DATA[1],
+        "time": TRAIN_DATA[2],
+        "eid": TRAIN_DATA[3]
+    })
 
 
 def set_graph_metadata(num_vertices: int, num_edges: int, max_vertex_id: int, num_partitions: int):

--- a/gnnflow/distributed/graph_services.py
+++ b/gnnflow/distributed/graph_services.py
@@ -23,6 +23,7 @@ global TEST_RAND_SAMPLER
 global VAL_RAND_SAMPLER
 
 global TRAIN_DATA
+TRAIN_DATA = None
 
 
 def get_dgraph() -> DistributedDynamicGraph:

--- a/gnnflow/distributed/partition.py
+++ b/gnnflow/distributed/partition.py
@@ -222,6 +222,8 @@ class Partitioner:
         # check the number of edges in each worker are the same
         for i in range(self._num_partitions):
             for j in range(self._local_world_size):
+                print("machine {} partition {} has {} edges".format(
+                    i, j, len(evenly_partitioned_dataset[i][j])))
                 assert len(evenly_partitioned_dataset[i][j]) == len(
                     evenly_partitioned_dataset[0][0])
 

--- a/gnnflow/distributed/partition.py
+++ b/gnnflow/distributed/partition.py
@@ -195,8 +195,8 @@ class Partitioner:
 
         # check the number of edges in each partition
         for i in range(self._num_partitions):
-            print("len(sorted_partitions[{}]): {}".format(
-                i, len(sorted_partitions[i])))
+            print("len(sorted_partitions[{}].src_nodes): {}".format(
+                i, len(sorted_partitions[i].src_nodes)))
             assert len(sorted_partitions[i]) == avg_num_edges
 
         # restore the order of partitions

--- a/gnnflow/distributed/partition.py
+++ b/gnnflow/distributed/partition.py
@@ -178,7 +178,7 @@ class Partitioner:
 
         # sort the partitions by the number of edges use argsort
         sorted_idx = torch.argsort(
-            torch.tensor([len(p) for p in partitions])).tolist()
+            torch.tensor([len(p.src_nodes) for p in partitions])).tolist()
         sorted_partitions = [deepcopy(partitions[i]) for i in sorted_idx]
 
         # move addtional edges from the last partition to the next partition

--- a/gnnflow/distributed/partition.py
+++ b/gnnflow/distributed/partition.py
@@ -174,6 +174,7 @@ class Partitioner:
         # average number of edges in each partition
         avg_num_edges = sum([len(p.src_nodes) for p in partitions]
                             ) // self._num_partitions
+        print("avg_num_edges: ", avg_num_edges)
 
         # sort the partitions by the number of edges use argsort
         sorted_idx = torch.argsort(
@@ -194,6 +195,8 @@ class Partitioner:
 
         # check the number of edges in each partition
         for i in range(self._num_partitions):
+            print("len(sorted_partitions[{}]): {}".format(
+                i, len(sorted_partitions[i])))
             assert len(sorted_partitions[i]) == avg_num_edges
 
         # restore the order of partitions

--- a/gnnflow/distributed/partition.py
+++ b/gnnflow/distributed/partition.py
@@ -174,7 +174,6 @@ class Partitioner:
         # average number of edges in each partition
         avg_num_edges = sum([len(p.src_nodes) for p in partitions]
                             ) // self._num_partitions
-        print("avg_num_edges: ", avg_num_edges)
 
         # sort the partitions by the number of edges use argsort
         sorted_idx = torch.argsort(
@@ -207,9 +206,9 @@ class Partitioner:
 
         # check the number of edges in each partition
         for i in range(self._num_partitions):
-            print("len(sorted_partitions[{}].src_nodes): {}".format(
-                i, len(sorted_partitions[i].src_nodes)))
-            assert len(sorted_partitions[i].src_nodes) == avg_num_edges
+            assert len(sorted_partitions[i].src_nodes) == avg_num_edges, "The \
+                    number of edges in partition {} is {}, but the average \
+                    number of edges is {}".format(i, len(sorted_partitions[i].src_nodes), avg_num_edges)
 
         # restore the order of partitions
         restored_partitions = [None] * self._num_partitions
@@ -242,10 +241,12 @@ class Partitioner:
         # check the number of edges in each worker are the same
         for i in range(self._num_partitions):
             for j in range(self._local_world_size):
-                print("machine {} partition {} has {} edges".format(
-                    i, j, len(evenly_partitioned_dataset[i][j].src_nodes)))
                 assert len(evenly_partitioned_dataset[i][j].src_nodes) == len(
-                    evenly_partitioned_dataset[0][0].src_nodes)
+                    evenly_partitioned_dataset[0][0].src_nodes), "The number of \
+                            edges in partition {} worker {} is {}, but the number \
+                            of edges in partition 0 worker 0 is {}".format(
+                    i, j, len(evenly_partitioned_dataset[i][j].src_nodes),
+                    len(evenly_partitioned_dataset[0][0].src_nodes))
 
         return evenly_partitioned_dataset
 

--- a/gnnflow/distributed/partition.py
+++ b/gnnflow/distributed/partition.py
@@ -172,7 +172,7 @@ class Partitioner:
             A evenly partitioned dataset.
         """
         # average number of edges in each partition
-        avg_num_edges = sum([len(p) for p in partitions]
+        avg_num_edges = sum([len(p.src_nodes) for p in partitions]
                             ) // self._num_partitions
 
         # sort the partitions by the number of edges use argsort
@@ -223,7 +223,7 @@ class Partitioner:
         for i in range(self._num_partitions):
             for j in range(self._local_world_size):
                 print("machine {} partition {} has {} edges".format(
-                    i, j, len(evenly_partitioned_dataset[i][j])))
+                    j, len(evenly_partitioned_dataset[i][j])))
                 assert len(evenly_partitioned_dataset[i][j]) == len(
                     evenly_partitioned_dataset[0][0])
 

--- a/gnnflow/distributed/partition.py
+++ b/gnnflow/distributed/partition.py
@@ -219,6 +219,12 @@ class Partitioner:
 
             evenly_partitioned_dataset.append(partitioned_dataset)
 
+        # check the number of edges in each worker are the same
+        for i in range(self._num_partitions):
+            for j in range(self._local_world_size):
+                assert len(evenly_partitioned_dataset[i][j]) == len(
+                    evenly_partitioned_dataset[0][0])
+
         return evenly_partitioned_dataset
 
     def get_partition_table(self) -> torch.Tensor:

--- a/gnnflow/distributed/partition.py
+++ b/gnnflow/distributed/partition.py
@@ -310,7 +310,7 @@ class LeastLoadedPartitioner(Partitioner):
     """
 
     def __init__(self, num_partitions: int, local_world_size: int, assign_with_dst_node: bool = False):
-        super().__init__(num_partitions, local_world_size: int, assign_with_dst_node)
+        super().__init__(num_partitions, local_world_size, assign_with_dst_node)
         self._metrics = torch.zeros(num_partitions, dtype=torch.float32)
 
     def _do_partition_for_unseen_nodes_impl(self, unique_src_nodes: torch.Tensor,

--- a/gnnflow/distributed/partition.py
+++ b/gnnflow/distributed/partition.py
@@ -219,10 +219,15 @@ class Partitioner:
         # for each partition, divide the edges into evenly sized chunks to multiple workers (local_world_size) interleavely
         evenly_partitioned_dataset = []
         for i in range(self._num_partitions):
-            src_nodes = restored_partitions[i].src_nodes
-            dst_nodes = restored_partitions[i].dst_nodes
-            timestamps = restored_partitions[i].timestamps
-            eids = restored_partitions[i].eids
+            num_edges_per_partition = len(restored_partitions[i].src_nodes)
+            # discard the last few edges if the number of edges is not divisible by local_world_size
+            num_edges_per_partition = num_edges_per_partition - (
+                num_edges_per_partition % self._local_world_size)
+
+            src_nodes = restored_partitions[i].src_nodes[:num_edges_per_partition]
+            dst_nodes = restored_partitions[i].dst_nodes[:num_edges_per_partition]
+            timestamps = restored_partitions[i].timestamps[:num_edges_per_partition]
+            eids = restored_partitions[i].eids[:num_edges_per_partition]
 
             partitioned_dataset = []
             for j in range(self._local_world_size):

--- a/gnnflow/distributed/partition.py
+++ b/gnnflow/distributed/partition.py
@@ -199,6 +199,12 @@ class Partitioner:
                 sorted_partitions[i].timestamps[:avg_num_edges],
                 sorted_partitions[i].eids[:avg_num_edges])
 
+        sorted_partitions[0] = Partition(
+            sorted_partitions[0].src_nodes[:avg_num_edges],
+            sorted_partitions[0].dst_nodes[:avg_num_edges],
+            sorted_partitions[0].timestamps[:avg_num_edges],
+            sorted_partitions[0].eids[:avg_num_edges])
+
         # check the number of edges in each partition
         for i in range(self._num_partitions):
             print("len(sorted_partitions[{}].src_nodes): {}".format(

--- a/gnnflow/distributed/partition.py
+++ b/gnnflow/distributed/partition.py
@@ -193,6 +193,12 @@ class Partitioner:
                 torch.cat([sorted_partitions[i - 1].eids,
                            sorted_partitions[i].eids[avg_num_edges:]]))
 
+            sorted_partitions[i] = Partition(
+                sorted_partitions[i].src_nodes[:avg_num_edges],
+                sorted_partitions[i].dst_nodes[:avg_num_edges],
+                sorted_partitions[i].timestamps[:avg_num_edges],
+                sorted_partitions[i].eids[:avg_num_edges])
+
         # check the number of edges in each partition
         for i in range(self._num_partitions):
             print("len(sorted_partitions[{}].src_nodes): {}".format(
@@ -226,9 +232,9 @@ class Partitioner:
         for i in range(self._num_partitions):
             for j in range(self._local_world_size):
                 print("machine {} partition {} has {} edges".format(
-                    j, len(evenly_partitioned_dataset[i][j])))
-                assert len(evenly_partitioned_dataset[i][j]) == len(
-                    evenly_partitioned_dataset[0][0])
+                    j, len(evenly_partitioned_dataset[i][j].src_nodes)))
+                assert len(evenly_partitioned_dataset[i][j].src_nodes) == len(
+                    evenly_partitioned_dataset[0][0].src_nodes)
 
         return evenly_partitioned_dataset
 

--- a/gnnflow/distributed/partition.py
+++ b/gnnflow/distributed/partition.py
@@ -232,7 +232,7 @@ class Partitioner:
         for i in range(self._num_partitions):
             for j in range(self._local_world_size):
                 print("machine {} partition {} has {} edges".format(
-                    j, len(evenly_partitioned_dataset[i][j].src_nodes)))
+                    i, j, len(evenly_partitioned_dataset[i][j].src_nodes)))
                 assert len(evenly_partitioned_dataset[i][j].src_nodes) == len(
                     evenly_partitioned_dataset[0][0].src_nodes)
 

--- a/gnnflow/distributed/partition.py
+++ b/gnnflow/distributed/partition.py
@@ -203,7 +203,7 @@ class Partitioner:
         for i in range(self._num_partitions):
             print("len(sorted_partitions[{}].src_nodes): {}".format(
                 i, len(sorted_partitions[i].src_nodes)))
-            assert len(sorted_partitions[i]) == avg_num_edges
+            assert len(sorted_partitions[i].src_nodes) == avg_num_edges
 
         # restore the order of partitions
         restored_partitions = [None] * self._num_partitions

--- a/gnnflow/utils.py
+++ b/gnnflow/utils.py
@@ -67,7 +67,7 @@ def load_dataset(dataset: str, data_dir: Optional[str] = None) -> \
     return train_data, val_data, test_data, full_data
 
 
-def load_partitioned_dataset(dataset: str, data_dir: Optional[str] = None, rank: int = 0, world_size: int = 1, partition_train_data: bool = False):
+def load_partitioned_dataset(dataset: str, data_dir: Optional[str] = None, rank: int = 0, world_size: int = 1, partition_training_data: bool = False):
     """
     Loads the partitioned dataset and returns the dataframes for the train, validation, test.
 
@@ -93,7 +93,7 @@ def load_partitioned_dataset(dataset: str, data_dir: Optional[str] = None, rank:
         raise ValueError('{} does not exist'.format(train_path))
 
     train_data = None
-    if not partition_train_data:
+    if not partition_training_data:
         train_data = pd.read_csv(train_path)
     assert isinstance(train_data, pd.DataFrame)
     val_data = pd.read_csv(val_path)

--- a/gnnflow/utils.py
+++ b/gnnflow/utils.py
@@ -95,7 +95,7 @@ def load_partitioned_dataset(dataset: str, data_dir: Optional[str] = None, rank:
     train_data = None
     if not partition_train_data:
         train_data = pd.read_csv(train_path)
-    assert isinstance(train_data, pd.DataFrame)
+        assert isinstance(train_data, pd.DataFrame)
     val_data = pd.read_csv(val_path)
     assert isinstance(val_data, pd.DataFrame)
     test_data = pd.read_csv(test_path)

--- a/gnnflow/utils.py
+++ b/gnnflow/utils.py
@@ -67,7 +67,7 @@ def load_dataset(dataset: str, data_dir: Optional[str] = None) -> \
     return train_data, val_data, test_data, full_data
 
 
-def load_partitioned_dataset(dataset: str, data_dir: Optional[str] = None, rank: int = 0, world_size: int = 1, partition_training_data: bool = False):
+def load_partitioned_dataset(dataset: str, data_dir: Optional[str] = None, rank: int = 0, world_size: int = 1, partition_train_data: bool = False):
     """
     Loads the partitioned dataset and returns the dataframes for the train, validation, test.
 
@@ -93,7 +93,7 @@ def load_partitioned_dataset(dataset: str, data_dir: Optional[str] = None, rank:
         raise ValueError('{} does not exist'.format(train_path))
 
     train_data = None
-    if not partition_training_data:
+    if not partition_train_data:
         train_data = pd.read_csv(train_path)
     assert isinstance(train_data, pd.DataFrame)
     val_data = pd.read_csv(val_path)

--- a/gnnflow/utils.py
+++ b/gnnflow/utils.py
@@ -67,8 +67,7 @@ def load_dataset(dataset: str, data_dir: Optional[str] = None) -> \
     return train_data, val_data, test_data, full_data
 
 
-def load_partitioned_dataset(dataset: str, data_dir: Optional[str] = None, rank: int = 0, world_size: int = 1) -> \
-        Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+def load_partitioned_dataset(dataset: str, data_dir: Optional[str] = None, rank: int = 0, world_size: int = 1, partition_train_data: bool = False):
     """
     Loads the partitioned dataset and returns the dataframes for the train, validation, test.
 
@@ -80,7 +79,6 @@ def load_partitioned_dataset(dataset: str, data_dir: Optional[str] = None, rank:
         train_data: the dataframe for the train dataset.
         val_data: the dataframe for the validation dataset.
         test_data: the dataframe for the test dataset.
-        full_data: the dataframe for the whole dataset.
     """
     if data_dir is None:
         data_dir = os.path.join(get_project_root_dir(), "data")
@@ -94,7 +92,9 @@ def load_partitioned_dataset(dataset: str, data_dir: Optional[str] = None, rank:
     if not os.path.exists(train_path):
         raise ValueError('{} does not exist'.format(train_path))
 
-    train_data = pd.read_csv(train_path)
+    train_data = None
+    if not partition_train_data:
+        train_data = pd.read_csv(train_path)
     assert isinstance(train_data, pd.DataFrame)
     val_data = pd.read_csv(val_path)
     assert isinstance(val_data, pd.DataFrame)

--- a/scripts/offline_edge_prediction_multi_node_kvstore.py
+++ b/scripts/offline_edge_prediction_multi_node_kvstore.py
@@ -73,7 +73,7 @@ parser.add_argument("--partition-strategy", type=str, default="roundrobin",
                     help="partition strategy for distributed training")
 parser.add_argument("--dynamic-scheduling", action="store_true",
                     help="whether to use dynamic scheduling")
-parser.add_argument("--partition-training-data", action="store_true",
+parser.add_argument("--partition-train-data", action="store_true",
                     help="whether to partition the training data")
 
 
@@ -176,7 +176,7 @@ def main():
                                        args.initial_ingestion_batch_size,
                                        args.ingestion_batch_size, args.partition_strategy,
                                        args.num_nodes, data_config["undirected"], args.data,
-                                       args.dim_memory, args.chunks, args.partition_training_data)
+                                       args.dim_memory, args.chunks, args.partition_train_data)
         # every worker will have a kvstore_client
         dim_node, dim_edge = graph_services.get_dim_node_edge()
         kvstore_client = KVStoreClient(
@@ -207,8 +207,8 @@ def main():
 
     train_data, val_data, test_data = load_partitioned_dataset(
         args.data, rank=args.rank, world_size=args.world_size,
-        partition_train_data=args.partition_training_data)
-    if args.partition_training_data:
+        partition_train_data=args.partition_train_data)
+    if args.partition_train_data:
         train_data = graph_services.get_train_data()
 
     train_ds = EdgePredictionDataset(train_data, train_rand_sampler)

--- a/scripts/offline_edge_prediction_multi_node_kvstore.py
+++ b/scripts/offline_edge_prediction_multi_node_kvstore.py
@@ -73,8 +73,8 @@ parser.add_argument("--partition-strategy", type=str, default="roundrobin",
                     help="partition strategy for distributed training")
 parser.add_argument("--dynamic-scheduling", action="store_true",
                     help="whether to use dynamic scheduling")
-parser.add_argument("--partition-train-data", action="store_true",
-                    help="whether to partition the training data")
+parser.add_argument("--not-partition-train-data", action="store_true",
+                    help="whether not to partition the training data")
 
 
 # dataset
@@ -176,7 +176,7 @@ def main():
                                        args.initial_ingestion_batch_size,
                                        args.ingestion_batch_size, args.partition_strategy,
                                        args.num_nodes, data_config["undirected"], args.data,
-                                       args.dim_memory, args.chunks, args.partition_train_data)
+                                       args.dim_memory, args.chunks, not args.not_partition_train_data)
         # every worker will have a kvstore_client
         dim_node, dim_edge = graph_services.get_dim_node_edge()
         kvstore_client = KVStoreClient(
@@ -207,8 +207,8 @@ def main():
 
     train_data, val_data, test_data = load_partitioned_dataset(
         args.data, rank=args.rank, world_size=args.world_size,
-        partition_train_data=args.partition_train_data)
-    if args.partition_train_data:
+        partition_train_data=not args.not_partition_train_data)
+    if not args.partition_train_data:
         train_data = graph_services.get_train_data()
 
     train_ds = EdgePredictionDataset(train_data, train_rand_sampler)

--- a/scripts/offline_edge_prediction_multi_node_kvstore.py
+++ b/scripts/offline_edge_prediction_multi_node_kvstore.py
@@ -208,7 +208,7 @@ def main():
     train_data, val_data, test_data = load_partitioned_dataset(
         args.data, rank=args.rank, world_size=args.world_size,
         partition_train_data=not args.not_partition_train_data)
-    if not args.partition_train_data:
+    if not args.not_partition_train_data:
         train_data = graph_services.get_train_data()
 
     train_ds = EdgePredictionDataset(train_data, train_rand_sampler)

--- a/scripts/offline_edge_prediction_multi_node_kvstore.py
+++ b/scripts/offline_edge_prediction_multi_node_kvstore.py
@@ -207,8 +207,8 @@ def main():
 
     train_data, val_data, test_data = load_partitioned_dataset(
         args.data, rank=args.rank, world_size=args.world_size,
-        partition_train_data=args.partition_train_data)
-    if args.partition_train_data:
+        partition_train_data=args.partition_training_data)
+    if args.partition_training_data:
         train_data = graph_services.get_train_data()
 
     train_ds = EdgePredictionDataset(train_data, train_rand_sampler)

--- a/scripts/run_offline_multi_node.sh
+++ b/scripts/run_offline_multi_node.sh
@@ -35,7 +35,6 @@ cmd="torchrun \
     --initial-ingestion-batch-size 500000 \
     --partition-strategy $PARTITION_STRATEGY \
     --epoch 5 --lr 0.0001 --num-workers 0
-    --partition-train-data
     "
 
 echo $cmd

--- a/scripts/run_offline_multi_node.sh
+++ b/scripts/run_offline_multi_node.sh
@@ -35,6 +35,7 @@ cmd="torchrun \
     --initial-ingestion-batch-size 500000 \
     --partition-strategy $PARTITION_STRATEGY \
     --epoch 5 --lr 0.0001 --num-workers 0
+    --partition-train-data
     "
 
 echo $cmd


### PR DESCRIPTION
Split training samples accoarding to partition resutls. The feature is on by defalt now. It can be turned off by adding `--not-partition-train-data` in the command line.

g1 g2, 2x2. TGN on REDDIT. no cache. hash partitioning. Python KVStore. 5 epochs 
| method | build graph (s) | training throughput (samples/s) | test ap | test auc |
| --- | --- | --- |  --- | --- |
| w/o | 3.7s  | 75425  | 97.7  | 97.7 |
| w/ | 4.1s | 80630 | 98.1 | 98.1 |

g1 g2, 2x2. TGAT on REDDIT. no cache. hash partitioning. Python KVStore. 5 epochs 
| method | build graph (s) | training throughput (samples/s) | test ap | test auc |
| --- | --- | --- |  --- | --- |
| w/o | 4.0s | 65950  | 97.8  | 97.6 |
| w/ | 3.7s | 66612 | 98.2 | 98.1 |

g15 g16, 2x4. TGN on REDDIT. no cache. hash partitioning. no dict. 5 epochs 
| method | build graph (s) | training throughput (samples/s) |  test ap| test auc |  
| --- | --- | --- | --- |  --- | 
| w/o | 2.7 |   155038 |  97.2  | 97.2  |
| w/ | 2.4 |  188783 | 97.7 | 97.5 |
