### PR TITLE
fix: put tgn memory outside forward function

### DIFF
--- a/scripts/offline_edge_prediction.py
+++ b/scripts/offline_edge_prediction.py
@@ -85,8 +85,15 @@ def evaluate(dataloader, sampler, model, criterion, cache, device):
             mfgs_to_cuda(mfgs, device)
             mfgs = cache.fetch_feature(
                 mfgs, eid)
-            pred_pos, pred_neg = model(
-                mfgs, edge_feats=cache.target_edge_features)
+            pred_pos, pred_neg = model(mfgs)
+
+            if model.has_memory():
+                # NB: no need to do backward here
+                # use one function
+                model.memory.update_mem_mail(
+                    **model.last_updated, edge_feats=cache.target_edge_features,
+                    neg_sample_ratio=1)
+
             total_loss += criterion(pred_pos, torch.ones_like(pred_pos))
             total_loss += criterion(pred_neg, torch.zeros_like(pred_neg))
             y_pred = torch.cat([pred_pos, pred_neg], dim=0).sigmoid().cpu()
@@ -270,8 +277,15 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
 
             # Train
             optimizer.zero_grad()
-            pred_pos, pred_neg = model(
-                mfgs, edge_feats=cache.target_edge_features)
+            pred_pos, pred_neg = model(mfgs)
+
+            if model.has_memory():
+                # NB: no need to do backward here
+                with torch.no_grad():
+                    # use one function
+                    model.memory.update_mem_mail(
+                        **model.last_updated, edge_feats=cache.target_edge_features,
+                        neg_sample_ratio=1)
 
             loss = criterion(pred_pos, torch.ones_like(pred_pos))
             loss += criterion(pred_neg, torch.zeros_like(pred_neg))

--- a/scripts/offline_edge_prediction_multi_node_kvstore.py
+++ b/scripts/offline_edge_prediction_multi_node_kvstore.py
@@ -113,11 +113,11 @@ def evaluate(dataloader, sampler, model, criterion, cache, device):
             mfgs = cache.fetch_feature(
                 mfgs, eid, target_edge_features=args.use_memory)
             pred_pos, pred_neg = model(mfgs)
-            if model.has_memory():
+            if args.use_memory:
                 # NB: no need to do backward here
                 # use one function
-                model.memory.update_mem_mail(
-                    **model.last_updated, edge_feats=cache.target_edge_features,
+                model.module.memory.update_mem_mail(
+                    **model.module.last_updated, edge_feats=cache.target_edge_features,
                     neg_sample_ratio=1)
             total_loss += criterion(pred_pos, torch.ones_like(pred_pos))
             total_loss += criterion(pred_neg, torch.zeros_like(pred_neg))
@@ -158,6 +158,7 @@ def main():
     set_seed(args.seed + args.rank)
 
     model_config, data_config = get_default_config(args.model, args.data)
+    args.use_memory = model_config['use_memory']
 
     if args.distributed:
         # graph is stored in shared memory
@@ -369,12 +370,12 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
             optimizer.zero_grad()
             pred_pos, pred_neg = model(mfgs)
 
-            if model.has_memory():
+            if args.use_memory:
                 # NB: no need to do backward here
                 with torch.no_grad():
                     # use one function
-                    model.memory.update_mem_mail(
-                        **model.last_updated, edge_feats=cache.target_edge_features,
+                    model.module.memory.update_mem_mail(
+                        **model.module.last_updated, edge_feats=cache.target_edge_features,
                         neg_sample_ratio=1)
 
             loss = criterion(pred_pos, torch.ones_like(pred_pos))


### PR DESCRIPTION
g1 g2, 2x2. TGN on REDDIT. no cache. hash partitioning. Python KVStore. 5 epochs 
| method | training throughput (samples/s) | test ap | test auc |
| --- | --- |  --- | --- |
| w/o | 75425  | 97.7  | 97.7 |
| w/ | 79376 |98.0 | 98.0 |