### PR TITLE
feat: offload old blocks 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,6 +192,7 @@ rmm_log.txt
 col*.txt
 row*.txt
 partition_table.txt
+*.bin
 
 # MacOS
 .DS_Store

--- a/gnnflow/csrc/api.cc
+++ b/gnnflow/csrc/api.cc
@@ -47,6 +47,8 @@ PYBIND11_MODULE(libgnnflow, m) {
            py::arg("device"), py::arg("adaptive_block_size"))
       .def("add_edges", &DynamicGraph::AddEdges, py::arg("source_vertices"),
            py::arg("target_vertices"), py::arg("timestamps"), py::arg("eids"))
+      .def("offload_old_blocks", &DynamicGraph::OffloadOldBlocks,
+           py::arg("timestamp"), py::arg("to_file") = false)
       .def("num_vertices", &DynamicGraph::num_nodes)
       .def("num_source_vertices", &DynamicGraph::num_src_nodes)
       .def("num_edges", &DynamicGraph::num_edges)

--- a/gnnflow/csrc/doubly_linked_list.cu
+++ b/gnnflow/csrc/doubly_linked_list.cu
@@ -19,11 +19,33 @@ __device__ void InsertBlockToDoublyLinkedList(DoublyLinkedList* node_table,
   }
 }
 
+__device__ void RemoveBlockFromDoublyLinkedList(DoublyLinkedList* node_table,
+                                                NIDType node_id,
+                                                TemporalBlock* block) {
+  auto& list = node_table[node_id];
+  if (block->prev == nullptr && block->next == nullptr) {
+    // only one block
+    list.tail = nullptr;
+  } else if (block->prev == nullptr) {
+    // block is the head
+    block->next->prev = nullptr;
+  } else if (block->next == nullptr) {
+    // block is the tail
+    list.tail = block->prev;
+    block->prev->next = nullptr;
+  } else {
+    // block is in the middle
+    block->prev->next = block->next;
+    block->next->prev = block->prev;
+  }
+}
+
 void InsertBlockToDoublyLinkedList(HostDoublyLinkedList* node_table,
                                    NIDType node_id, TemporalBlock* block) {
   auto& list = node_table[node_id];
   if (list.tail == nullptr) {
     list.tail = block;
+    list.head = block;
     block->prev = nullptr;
     block->next = nullptr;
   } else {
@@ -36,9 +58,35 @@ void InsertBlockToDoublyLinkedList(HostDoublyLinkedList* node_table,
   list.size++;
 }
 
+void RemoveBlockFromDoublyLinkedList(HostDoublyLinkedList* node_table,
+                                     NIDType node_id, TemporalBlock* block) {
+  auto& list = node_table[node_id];
+  if (block->prev == nullptr && block->next == nullptr) {
+    // only one block
+    list.head = list.tail = nullptr;
+  } else if (block->prev == nullptr) {
+    // block is the head
+    list.head = block->next;
+    block->next->prev = nullptr;
+  } else if (block->next == nullptr) {
+    // block is the tail
+    list.tail = block->prev;
+    block->prev->next = nullptr;
+  } else {
+    // block is in the middle
+    block->prev->next = block->next;
+    block->next->prev = block->prev;
+  }
+  list.size--;
+}
+
 __global__ void InsertBlockToDoublyLinkedListKernel(
     DoublyLinkedList* node_table, NIDType node_id, TemporalBlock* block) {
   InsertBlockToDoublyLinkedList(node_table, node_id, block);
 }
 
+__global__ void RemoveBlockFromDoublyLinkedListKernel(
+    DoublyLinkedList* node_table, NIDType node_id, TemporalBlock* next_block) {
+  RemoveBlockFromDoublyLinkedList(node_table, node_id, next_block);
+}
 }  // namespace gnnflow

--- a/gnnflow/csrc/doubly_linked_list.h
+++ b/gnnflow/csrc/doubly_linked_list.h
@@ -19,24 +19,39 @@ struct DoublyLinkedList {
 };
 
 struct HostDoublyLinkedList {
+  TemporalBlock* head;
   TemporalBlock* tail;
   std::size_t num_edges;
   std::size_t num_insertions;
   std::size_t size;
 
   HostDoublyLinkedList()
-      : tail(nullptr), num_edges(0), num_insertions(0), size(0) {}
+      : head(nullptr),
+        tail(nullptr),
+        num_edges(0),
+        num_insertions(0),
+        size(0) {}
 };
 
 __device__ void InsertBlockToDoublyLinkedList(DoublyLinkedList* node_table,
                                               NIDType node_id,
                                               TemporalBlock* block);
 
+__device__ void RemoveBlockFromDoublyLinkedList(DoublyLinkedList* node_table,
+                                                NIDType node_id,
+                                                TemporalBlock* block);
+
 void InsertBlockToDoublyLinkedList(HostDoublyLinkedList* node_table,
                                    NIDType node_id, TemporalBlock* block);
 
+void RemoveBlockFromDoublyLinkedList(HostDoublyLinkedList* node_table,
+                                     NIDType node_id, TemporalBlock* block);
+
 __global__ void InsertBlockToDoublyLinkedListKernel(
     DoublyLinkedList* node_table, NIDType node_id, TemporalBlock* block);
+
+__global__ void RemoveBlockFromDoublyLinkedListKernel(
+    DoublyLinkedList* node_table, NIDType node_id, TemporalBlock* next_block);
 
 }  // namespace gnnflow
 #endif  // GNNFLOW_DOUBLY_LINKED_LIST_H_

--- a/gnnflow/csrc/dynamic_graph.cu
+++ b/gnnflow/csrc/dynamic_graph.cu
@@ -397,10 +397,10 @@ std::size_t DynamicGraph::OffloadOldBlocks(TimestampType timestamp,
           }
         }
 
+        RemoveBlock(node, cur);
         if (to_file) {
           allocator_.SaveToFile(cur, node);
         } else {
-          RemoveBlock(node, cur);
           allocator_.Deallocate(cur);  // `delete block`
         }
         num_blocks++;

--- a/gnnflow/csrc/dynamic_graph.h
+++ b/gnnflow/csrc/dynamic_graph.h
@@ -75,6 +75,16 @@ class DynamicGraph {
    */
   void AddNodes(NIDType max_node);
 
+  /**
+   * @brief Offload all blocks that are older than the given timestamp.
+   *
+   * @params src_node The source node of the blocks.
+   * @params timestamp The timestamp of the blocks.
+   *
+   * @return The number of blocks offloaded.
+   */
+  std::size_t OffloadOldBlocks(TimestampType timestamp, bool to_file = false);
+
   std::size_t num_nodes() const;
   std::size_t num_edges() const;
   std::size_t num_src_nodes() const;
@@ -115,6 +125,9 @@ class DynamicGraph {
   void InsertBlock(NIDType node_id, TemporalBlock* block,
                    cudaStream_t stream = nullptr);
 
+  void RemoveBlock(NIDType node_id, TemporalBlock* block,
+                   cudaStream_t stream = nullptr);
+
   void SyncBlock(TemporalBlock* block, cudaStream_t stream = nullptr);
 
  private:
@@ -137,7 +150,7 @@ class DynamicGraph {
 
   std::set<NIDType> nodes_;
   std::set<NIDType> src_nodes_;
-  std::set<EIDType> edges_;
+  std::unordered_map<EIDType, std::size_t> edges_;
 
   std::stack<rmm::mr::device_memory_resource*> mem_resources_for_metadata_;
 

--- a/gnnflow/csrc/sampling_kernels.cu
+++ b/gnnflow/csrc/sampling_kernels.cu
@@ -37,7 +37,7 @@ __global__ void SampleLayerRecentKernel(
   uint32_t offset = tid * fanout;
   int start_idx, end_idx;
   uint32_t sampled = 0;
-  while (curr != nullptr && sampled < fanout) {
+  while (curr != nullptr && curr->capacity > 0 && sampled < fanout) {
     if (end_timestamp < curr->start_timestamp) {
       // search in the previous block
       curr = curr->prev;
@@ -128,7 +128,7 @@ __global__ void SampleLayerUniformKernel(
   int start_idx, end_idx;
   int curr_idx = 0;
   const int offset_by_thread = offset_per_thread * threadIdx.x;
-  while (curr != nullptr) {
+  while (curr != nullptr && curr->capacity > 0) {
     if (end_timestamp < curr->start_timestamp) {
       // search in the prev block
       curr = curr->prev;
@@ -186,7 +186,7 @@ __global__ void SampleLayerUniformKernel(
   curr = list.tail;
   curr_idx = 0;
   uint32_t cumsum = 0;
-  while (curr != nullptr) {
+  while (curr != nullptr && curr->capacity > 0) {
     if (end_timestamp < curr->start_timestamp) {
       // search in the prev block
       curr = curr->prev;

--- a/gnnflow/csrc/temporal_block_allocator.h
+++ b/gnnflow/csrc/temporal_block_allocator.h
@@ -75,6 +75,9 @@ class TemporalBlockAllocator {
   void Reallocate(TemporalBlock* block, std::size_t size,
                   cudaStream_t stream = nullptr);
 
+  void SaveToFile(TemporalBlock* block, NIDType src_node);
+  void ReadFromFile(TemporalBlock* block, NIDType src_node);
+
   std::size_t get_total_memory_usage() const { return allocated_; }
 
  private:
@@ -87,7 +90,11 @@ class TemporalBlockAllocator {
   std::vector<TemporalBlock*> blocks_;
 
   std::size_t minium_block_size_;
+  MemoryResourceType mem_resource_type_;
   std::stack<rmm::mr::device_memory_resource*> mem_resources_;
+
+  std::unordered_map<TemporalBlock*, std::string> saved_blocks_;
+  std::unordered_map<NIDType, std::size_t> num_saved_blocks_;
 
   std::mutex mutex_;
 

--- a/gnnflow/dynamic_graph.py
+++ b/gnnflow/dynamic_graph.py
@@ -2,7 +2,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 
-from libgnnflow import MemoryResourceType, InsertionPolicy, _DynamicGraph
+from libgnnflow import InsertionPolicy, MemoryResourceType, _DynamicGraph
 
 
 class DynamicGraph:
@@ -124,6 +124,19 @@ class DynamicGraph:
 
         self._dgraph.add_edges(
             source_vertices, target_vertices, timestamps, eids)
+
+    def offload_old_blocks(self, timestamp: float, to_file: bool = False):
+        """
+        Offload the old blocks from the graph.
+
+        Args:
+            timestamp: the current timestamp.
+            to_file: whether to offload the blocks to file.
+
+        Return:
+            the number of blocks offloaded.
+        """
+        return self._dgraph.offload_old_blocks(timestamp, to_file)
 
     def num_vertices(self) -> int:
         return self._dgraph.num_vertices()

--- a/tests/test_dynamic_graph.py
+++ b/tests/test_dynamic_graph.py
@@ -21,453 +21,504 @@ default_config = {
 
 class TestDynamicGraph(unittest.TestCase):
 
+    #    @parameterized.expand(
+    #        itertools.product(["cuda", "unified", "pinned", "shared"]))
+    #    def test_add_edges_sorted_by_timestamp(self, mem_resource_type):
+    #        """
+    #        Test that adding edges sorted by timestamps works.
+    #        """
+    #        config = default_config.copy()
+    #        config["mem_resource_type"] = mem_resource_type
+    #        dgraph = DynamicGraph(**config)
+    #
+    #        source_vertices = np.array(
+    #            [0, 0, 0, 1, 1, 1, 2, 2, 2])
+    #        target_vertices = np.array(
+    #            [1, 2, 3, 1, 2, 3, 1, 2, 3])
+    #        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
+    #        dgraph.add_edges(source_vertices, target_vertices,
+    #                         timestamps, add_reverse=False)
+    #        self.assertEqual(dgraph.num_edges(), 9)
+    #        self.assertEqual(dgraph.num_vertices(), 4)
+    #        self.assertEqual(dgraph.out_degree(
+    #            [0, 1, 2, 3]).tolist(), [3, 3, 3, 0])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            0)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [2, 1, 0])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            1)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [5, 4, 3])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            2)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [8, 7, 6])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            3)
+    #        self.assertEqual(target_vertices.tolist(), [])
+    #        self.assertEqual(timestamps.tolist(), [])
+    #        self.assertEqual(edge_ids.tolist(), [])
+    #        print("Test add edges sorted by timestamps passed. (mem_resource_type: {})".format(
+    #            mem_resource_type))
+    #
+    #    @ parameterized.expand(
+    #        itertools.product(["cuda", "unified", "pinned", "shared"]))
+    #    def test_add_edges_sorted_by_timestamps_add_reverse(
+    #            self, mem_resource_type):
+    #        """
+    #        Test that adding edges sorted by timestamps works.
+    #        """
+    #        config = default_config.copy()
+    #        config["mem_resource_type"] = mem_resource_type
+    #        dgraph = DynamicGraph(**config)
+    #        source_vertices = np.array(
+    #            [0, 0, 0, 1, 1, 1, 2, 2, 2])
+    #        target_vertices = np.array(
+    #            [1, 2, 3, 1, 2, 3, 1, 2, 3])
+    #        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
+    #        dgraph.add_edges(source_vertices, target_vertices,
+    #                         timestamps, add_reverse=True)
+    #        self.assertEqual(dgraph.num_edges(), 9)
+    #        self.assertEqual(dgraph.num_vertices(), 4)
+    #        self.assertEqual(dgraph.out_degree(
+    #            [0, 1, 2, 3]).tolist(), [3, 6, 6, 3])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            0)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [2, 1, 0])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            1)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 2, 1, 0, 1])
+    #        self.assertEqual(timestamps.tolist(), [2, 1, 0, 0, 0, 0])
+    #        self.assertEqual(edge_ids.tolist(), [5, 4, 6, 3, 0, 3])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            2)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 0, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [2, 1, 1, 1, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [8, 7, 4, 1, 7, 6])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            3)
+    #        self.assertEqual(target_vertices.tolist(), [2, 1, 0])
+    #        self.assertEqual(timestamps.tolist(), [2, 2, 2])
+    #        self.assertEqual(edge_ids.tolist(), [8, 5, 2])
+    #        print("Test add edges sorted by timestamps passed (add reverse) (mem_resource_type: {})".format(
+    #            mem_resource_type))
+    #
+    #    @ parameterized.expand(
+    #        itertools.product(["cuda", "unified", "pinned", "shared"]))
+    #    def test_add_edges_unsorted(self, mem_resource_type):
+    #        """
+    #        Test that adding edges unsorted works.
+    #        """
+    #        config = default_config.copy()
+    #        config["mem_resource_type"] = mem_resource_type
+    #        dgraph = DynamicGraph(**config)
+    #        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+    #        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+    #        timestamps = np.array([2, 1, 0, 2, 1, 0, 2, 1, 0])
+    #        dgraph.add_edges(source_vertices, target_vertices,
+    #                         timestamps, add_reverse=False)
+    #        self.assertEqual(dgraph.num_edges(), 9)
+    #        self.assertEqual(dgraph.num_vertices(), 4)
+    #        self.assertEqual(dgraph.out_degree(
+    #            [0, 1, 2, 3]).tolist(), [3, 3, 3, 0])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            0)
+    #        self.assertEqual(target_vertices.tolist(), [1, 2, 3])
+    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [0, 1, 2])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            1)
+    #        self.assertEqual(target_vertices.tolist(), [1, 2, 3])
+    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [3, 4, 5])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            2)
+    #        self.assertEqual(target_vertices.tolist(), [1, 2, 3])
+    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [6, 7, 8])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            3)
+    #        self.assertEqual(target_vertices.tolist(), [])
+    #        self.assertEqual(timestamps.tolist(), [])
+    #        self.assertEqual(edge_ids.tolist(), [])
+    #        print("Test add edges unsorted passed (mem_resource_type: {})".format(
+    #            mem_resource_type))
+    #
+    #    @ parameterized.expand(
+    #        itertools.product(["cuda", "unified", "pinned", "shared"]))
+    #    def test_add_edges_multiple_times_insert(self, mem_resource_type):
+    #        """
+    #        Test that adding edges multiple times works.
+    #        """
+    #        config = default_config.copy()
+    #        config["minimum_block_size"] = 4
+    #        config["mem_resource_type"] = mem_resource_type
+    #        dgraph = DynamicGraph(**config)
+    #        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+    #        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+    #        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
+    #        dgraph.add_edges(source_vertices, target_vertices,
+    #                         timestamps, add_reverse=False)
+    #        self.assertEqual(dgraph.num_edges(), 9)
+    #        self.assertEqual(dgraph.num_vertices(), 4)
+    #        self.assertEqual(dgraph.out_degree(
+    #            [0, 1, 2, 3]).tolist(), [3, 3, 3, 0])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            0)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [2, 1, 0])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            1)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [5, 4, 3])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            2)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [8, 7, 6])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            3)
+    #        self.assertEqual(target_vertices.tolist(), [])
+    #        self.assertEqual(timestamps.tolist(), [])
+    #        self.assertEqual(edge_ids.tolist(), [])
+    #
+    #        # edges with newer timestamps should be added
+    #        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+    #        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+    #        timestamps = np.array([3, 4, 5, 3, 4, 5, 3, 4, 5])
+    #        dgraph.add_edges(source_vertices, target_vertices,
+    #                         timestamps, add_reverse=False)
+    #        self.assertEqual(dgraph.num_edges(), 18)
+    #        self.assertEqual(dgraph.num_vertices(), 4)
+    #        self.assertEqual(dgraph.out_degree(
+    #            [0, 1, 2, 3]).tolist(), [6, 6, 6, 0])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            0)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [11, 10, 9, 2, 1, 0])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            1)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [14, 13, 12, 5, 4, 3])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            2)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [17, 16, 15, 8, 7, 6])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            3)
+    #        self.assertEqual(target_vertices.tolist(), [])
+    #        self.assertEqual(timestamps.tolist(), [])
+    #        self.assertEqual(edge_ids.tolist(), [])
+    #        print("Test add edges multiple times passed. (insert policy) (mem_resource_type: {})".format(
+    #            mem_resource_type))
+    #
+    #    @ parameterized.expand(
+    #        itertools.product(["cuda", "unified", "pinned", "shared"]))
+    #    def test_add_edges_multiple_times_replace(self, mem_resource_type):
+    #        """
+    #        Test that adding edges multiple times works.
+    #        """
+    #        config = default_config.copy()
+    #        config["minimum_block_size"] = 4
+    #        config["insertion_policy"] = "replace"
+    #        config["mem_resource_type"] = mem_resource_type
+    #        dgraph = DynamicGraph(**config)
+    #        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+    #        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+    #        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
+    #        dgraph.add_edges(source_vertices, target_vertices,
+    #                         timestamps, add_reverse=False)
+    #        self.assertEqual(dgraph.num_edges(), 9)
+    #        self.assertEqual(dgraph.num_vertices(), 4)
+    #        self.assertEqual(dgraph.out_degree(
+    #            [0, 1, 2, 3]).tolist(), [3, 3, 3, 0])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            0)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [2, 1, 0])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            1)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [5, 4, 3])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            2)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [8, 7, 6])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            3)
+    #        self.assertEqual(target_vertices.tolist(), [])
+    #        self.assertEqual(timestamps.tolist(), [])
+    #        self.assertEqual(edge_ids.tolist(), [])
+    #
+    #        # edges with newer timestamps should be added
+    #        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+    #        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+    #        timestamps = np.array([3, 4, 5, 3, 4, 5, 3, 4, 5])
+    #        dgraph.add_edges(source_vertices, target_vertices,
+    #                         timestamps, add_reverse=False)
+    #        self.assertEqual(dgraph.num_edges(), 18)
+    #        self.assertEqual(dgraph.num_vertices(), 4)
+    #        self.assertEqual(dgraph.out_degree(
+    #            [0, 1, 2, 3]).tolist(), [6, 6, 6, 0])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            0)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [11, 10, 9, 2, 1, 0])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            1)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [14, 13, 12, 5, 4, 3])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            2)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [17, 16, 15, 8, 7, 6])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            3)
+    #        self.assertEqual(target_vertices.tolist(), [])
+    #        self.assertEqual(timestamps.tolist(), [])
+    #        self.assertEqual(edge_ids.tolist(), [])
+    #        print("Test add edges multiple times passed. (replace policy) (mem_resource_type: {})".format(
+    #            mem_resource_type))
+    #
+    #    @unittest.skip("Not implemented yet")
+    #    def test_add_old_edges(self):
+    #        """
+    #        Test if raise an exception when adding edges with timestmaps that are
+    #        smaller than the current timestamps.
+    #        """
+    #        config = default_config.copy()
+    #        dgraph = DynamicGraph(**config)
+    #        source_vertices = np.array([0, 1, 2])
+    #        target_vertices = np.array([1, 2, 3])
+    #        timestamps = np.array([0, 1, 2])
+    #        dgraph.add_edges(source_vertices, target_vertices,
+    #                         timestamps, add_reverse=False)
+    #
+    #        source_vertices = np.array([0])
+    #        target_vertices = np.array([1])
+    #        timestamps = np.array([0])
+    #        with self.assertRaises(ValueError):
+    #            dgraph.add_edges(source_vertices, target_vertices, timestamps)
+    #
+    #        print("Test add old edges passed.")
+    #
+    #    @parameterized.expand(
+    #        itertools.product(["cuda", "unified", "pinned", "shared"]))
+    #    def test_insertion_policy_replace(self, mem_resource_type):
+    #        """
+    #        Test if the "replace" insertion policy works.
+    #        """
+    #        config = default_config.copy()
+    #        config["minimum_block_size"] = 4
+    #        config["insertion_policy"] = "replace"
+    #        config["mem_resource_type"] = mem_resource_type
+    #        dgraph = DynamicGraph(**config)
+    #        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+    #        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+    #        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
+    #        dgraph.add_edges(source_vertices, target_vertices,
+    #                         timestamps, add_reverse=False)
+    #
+    #        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+    #        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+    #        timestamps = np.array([3, 4, 5, 3, 4, 5, 3, 4, 5])
+    #        dgraph.add_edges(source_vertices, target_vertices,
+    #                         timestamps, add_reverse=False)
+    #
+    #        self.assertEqual(dgraph.num_edges(), 18)
+    #        self.assertEqual(dgraph.num_vertices(), 4)
+    #        self.assertEqual(dgraph.out_degree(
+    #            [0, 1, 2, 3]).tolist(), [6, 6, 6, 0])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            0)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [11, 10, 9, 2, 1, 0])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            1)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [14, 13, 12, 5, 4, 3])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            2)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [17, 16, 15, 8, 7, 6])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            3)
+    #        self.assertEqual(target_vertices.tolist(), [])
+    #        self.assertEqual(timestamps.tolist(), [])
+    #        self.assertEqual(edge_ids.tolist(), [])
+    #
+    #        print("Test replace insertion policy passed. (mem_resource_type: {})".format(
+    #            mem_resource_type))
+    #
+    #    @parameterized.expand(
+    #        itertools.product(["cuda", "unified", "pinned", "shared"]))
+    #    def test_add_edges_with_eids(self, mem_resource_type):
+    #        """
+    #        Test if the "replace" insertion policy works.
+    #        """
+    #        config = default_config.copy()
+    #        config["minimum_block_size"] = 4
+    #        config["mem_resource_type"] = mem_resource_type
+    #        dgraph = DynamicGraph(**config)
+    #        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+    #        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+    #        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
+    #        edge_ids = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8])
+    #        dgraph.add_edges(source_vertices, target_vertices,
+    #                         timestamps, edge_ids, add_reverse=False)
+    #
+    #        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+    #        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+    #        timestamps = np.array([3, 4, 5, 3, 4, 5, 3, 4, 5])
+    #        edge_ids = np.array([9, 10, 11, 12, 13, 14, 15, 16, 17])
+    #        dgraph.add_edges(source_vertices, target_vertices,
+    #                         timestamps, edge_ids, add_reverse=False)
+    #
+    #        self.assertEqual(dgraph.num_edges(), 18)
+    #        self.assertEqual(dgraph.num_vertices(), 4)
+    #        self.assertEqual(dgraph.out_degree(
+    #            [0, 1, 2, 3]).tolist(), [6, 6, 6, 0])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            0)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [11, 10, 9, 2, 1, 0])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            1)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [14, 13, 12, 5, 4, 3])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            2)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [17, 16, 15, 8, 7, 6])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            3)
+    #        self.assertEqual(target_vertices.tolist(), [])
+    #        self.assertEqual(timestamps.tolist(), [])
+    #        self.assertEqual(edge_ids.tolist(), [])
+    #
+    #        print("Test add edges with eids passed. (mem_resource_type: {})".format(
+    #            mem_resource_type))
+    #
+    #    @parameterized.expand(
+    #        itertools.product(["cuda", "unified", "pinned", "shared"]))
+    #    def test_add_edges_with_noncontinous_eids(self, mem_resource_type):
+    #        """
+    #        Test if the "replace" insertion policy works.
+    #        """
+    #        config = default_config.copy()
+    #        config["minimum_block_size"] = 4
+    #        config["mem_resource_type"] = mem_resource_type
+    #        dgraph = DynamicGraph(**config)
+    #        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+    #        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+    #        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
+    #        edge_ids = np.array([0, 2, 4, 6, 8, 10, 12, 14, 16])
+    #        dgraph.add_edges(source_vertices, target_vertices,
+    #                         timestamps, edge_ids, add_reverse=False)
+    #
+    #        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+    #        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+    #        timestamps = np.array([3, 4, 5, 3, 4, 5, 3, 4, 5])
+    #        edge_ids = np.array([17, 19, 21, 23, 25, 27, 29, 31, 33])
+    #        dgraph.add_edges(source_vertices, target_vertices,
+    #                         timestamps, edge_ids, add_reverse=False)
+    #
+    #        self.assertEqual(dgraph.num_edges(), 18)
+    #        self.assertEqual(dgraph.num_vertices(), 4)
+    #        self.assertEqual(dgraph.out_degree(
+    #            [0, 1, 2, 3]).tolist(), [6, 6, 6, 0])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            0)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [21, 19, 17, 4, 2, 0])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            1)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [27, 25, 23, 10, 8, 6])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            2)
+    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+    #        self.assertEqual(edge_ids.tolist(), [33, 31, 29, 16, 14, 12])
+    #
+    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+    #            3)
+    #        self.assertEqual(target_vertices.tolist(), [])
+    #        self.assertEqual(timestamps.tolist(), [])
+    #        self.assertEqual(edge_ids.tolist(), [])
+    #
+    #        print("Test add edges with non-continous eids passed. (mem_resource_type: {})".format(
+    #            mem_resource_type))
+
     @parameterized.expand(
-        itertools.product(["cuda", "unified", "pinned", "shared"]))
-    def test_add_edges_sorted_by_timestamp(self, mem_resource_type):
+        itertools.product(["pinned"], [True, False]))
+    def test_offload_old_blocks(self, mem_resource_type, to_file):
         """
-        Test that adding edges sorted by timestamps works.
-        """
-        config = default_config.copy()
-        config["mem_resource_type"] = mem_resource_type
-        dgraph = DynamicGraph(**config)
-
-        source_vertices = np.array(
-            [0, 0, 0, 1, 1, 1, 2, 2, 2])
-        target_vertices = np.array(
-            [1, 2, 3, 1, 2, 3, 1, 2, 3])
-        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
-        dgraph.add_edges(source_vertices, target_vertices,
-                         timestamps, add_reverse=False)
-        self.assertEqual(dgraph.num_edges(), 9)
-        self.assertEqual(dgraph.num_vertices(), 4)
-        self.assertEqual(dgraph.num_source_vertices(), 3)
-        self.assertEqual(dgraph.out_degree(
-            [0, 1, 2, 3]).tolist(), [3, 3, 3, 0])
-
-        self.assertEqual(dgraph.nodes().tolist(), [0, 1, 2, 3])
-        self.assertEqual(dgraph.src_nodes().tolist(), [0, 1, 2])
-        self.assertEqual(dgraph.edges().tolist(), [0, 1, 2, 3, 4, 5, 6, 7, 8])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            0)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [2, 1, 0])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            1)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [5, 4, 3])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            2)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [8, 7, 6])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            3)
-        self.assertEqual(target_vertices.tolist(), [])
-        self.assertEqual(timestamps.tolist(), [])
-        self.assertEqual(edge_ids.tolist(), [])
-        print("Test add edges sorted by timestamps passed. (mem_resource_type: {})".format(
-            mem_resource_type))
-
-    @ parameterized.expand(
-        itertools.product(["cuda", "unified", "pinned", "shared"]))
-    def test_add_edges_sorted_by_timestamps_add_reverse(
-            self, mem_resource_type):
-        """
-        Test that adding edges sorted by timestamps works.
-        """
-        config = default_config.copy()
-        config["mem_resource_type"] = mem_resource_type
-        dgraph = DynamicGraph(**config)
-        source_vertices = np.array(
-            [0, 0, 0, 1, 1, 1, 2, 2, 2])
-        target_vertices = np.array(
-            [1, 2, 3, 1, 2, 3, 1, 2, 3])
-        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
-        dgraph.add_edges(source_vertices, target_vertices,
-                         timestamps, add_reverse=True)
-        self.assertEqual(dgraph.num_edges(), 9)
-        self.assertEqual(dgraph.num_vertices(), 4)
-        self.assertEqual(dgraph.out_degree(
-            [0, 1, 2, 3]).tolist(), [3, 6, 6, 3])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            0)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [2, 1, 0])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            1)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 2, 1, 0, 1])
-        self.assertEqual(timestamps.tolist(), [2, 1, 0, 0, 0, 0])
-        self.assertEqual(edge_ids.tolist(), [5, 4, 6, 3, 0, 3])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            2)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 0, 2, 1])
-        self.assertEqual(timestamps.tolist(), [2, 1, 1, 1, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [8, 7, 4, 1, 7, 6])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            3)
-        self.assertEqual(target_vertices.tolist(), [2, 1, 0])
-        self.assertEqual(timestamps.tolist(), [2, 2, 2])
-        self.assertEqual(edge_ids.tolist(), [8, 5, 2])
-        print("Test add edges sorted by timestamps passed (add reverse) (mem_resource_type: {})".format(
-            mem_resource_type))
-
-    @ parameterized.expand(
-        itertools.product(["cuda", "unified", "pinned", "shared"]))
-    def test_add_edges_unsorted(self, mem_resource_type):
-        """
-        Test that adding edges unsorted works.
-        """
-        config = default_config.copy()
-        config["mem_resource_type"] = mem_resource_type
-        dgraph = DynamicGraph(**config)
-        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
-        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
-        timestamps = np.array([2, 1, 0, 2, 1, 0, 2, 1, 0])
-        dgraph.add_edges(source_vertices, target_vertices,
-                         timestamps, add_reverse=False)
-        self.assertEqual(dgraph.num_edges(), 9)
-        self.assertEqual(dgraph.num_vertices(), 4)
-        self.assertEqual(dgraph.out_degree(
-            [0, 1, 2, 3]).tolist(), [3, 3, 3, 0])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            0)
-        self.assertEqual(target_vertices.tolist(), [1, 2, 3])
-        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [0, 1, 2])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            1)
-        self.assertEqual(target_vertices.tolist(), [1, 2, 3])
-        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [3, 4, 5])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            2)
-        self.assertEqual(target_vertices.tolist(), [1, 2, 3])
-        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [6, 7, 8])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            3)
-        self.assertEqual(target_vertices.tolist(), [])
-        self.assertEqual(timestamps.tolist(), [])
-        self.assertEqual(edge_ids.tolist(), [])
-        print("Test add edges unsorted passed (mem_resource_type: {})".format(
-            mem_resource_type))
-
-    @ parameterized.expand(
-        itertools.product(["cuda", "unified", "pinned", "shared"]))
-    def test_add_edges_multiple_times_insert(self, mem_resource_type):
-        """
-        Test that adding edges multiple times works.
-        """
-        config = default_config.copy()
-        config["minimum_block_size"] = 4
-        config["mem_resource_type"] = mem_resource_type
-        dgraph = DynamicGraph(**config)
-        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
-        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
-        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
-        dgraph.add_edges(source_vertices, target_vertices,
-                         timestamps, add_reverse=False)
-        self.assertEqual(dgraph.num_edges(), 9)
-        self.assertEqual(dgraph.num_vertices(), 4)
-        self.assertEqual(dgraph.out_degree(
-            [0, 1, 2, 3]).tolist(), [3, 3, 3, 0])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            0)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [2, 1, 0])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            1)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [5, 4, 3])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            2)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [8, 7, 6])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            3)
-        self.assertEqual(target_vertices.tolist(), [])
-        self.assertEqual(timestamps.tolist(), [])
-        self.assertEqual(edge_ids.tolist(), [])
-
-        # edges with newer timestamps should be added
-        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
-        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
-        timestamps = np.array([3, 4, 5, 3, 4, 5, 3, 4, 5])
-        dgraph.add_edges(source_vertices, target_vertices,
-                         timestamps, add_reverse=False)
-        self.assertEqual(dgraph.num_edges(), 18)
-        self.assertEqual(dgraph.num_vertices(), 4)
-        self.assertEqual(dgraph.out_degree(
-            [0, 1, 2, 3]).tolist(), [6, 6, 6, 0])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            0)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [11, 10, 9, 2, 1, 0])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            1)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [14, 13, 12, 5, 4, 3])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            2)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [17, 16, 15, 8, 7, 6])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            3)
-        self.assertEqual(target_vertices.tolist(), [])
-        self.assertEqual(timestamps.tolist(), [])
-        self.assertEqual(edge_ids.tolist(), [])
-        print("Test add edges multiple times passed. (insert policy) (mem_resource_type: {})".format(
-            mem_resource_type))
-
-    @ parameterized.expand(
-        itertools.product(["cuda", "unified", "pinned", "shared"]))
-    def test_add_edges_multiple_times_replace(self, mem_resource_type):
-        """
-        Test that adding edges multiple times works.
-        """
-        config = default_config.copy()
-        config["minimum_block_size"] = 4
-        config["insertion_policy"] = "replace"
-        config["mem_resource_type"] = mem_resource_type
-        dgraph = DynamicGraph(**config)
-        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
-        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
-        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
-        dgraph.add_edges(source_vertices, target_vertices,
-                         timestamps, add_reverse=False)
-        self.assertEqual(dgraph.num_edges(), 9)
-        self.assertEqual(dgraph.num_vertices(), 4)
-        self.assertEqual(dgraph.out_degree(
-            [0, 1, 2, 3]).tolist(), [3, 3, 3, 0])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            0)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [2, 1, 0])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            1)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [5, 4, 3])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            2)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [8, 7, 6])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            3)
-        self.assertEqual(target_vertices.tolist(), [])
-        self.assertEqual(timestamps.tolist(), [])
-        self.assertEqual(edge_ids.tolist(), [])
-
-        # edges with newer timestamps should be added
-        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
-        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
-        timestamps = np.array([3, 4, 5, 3, 4, 5, 3, 4, 5])
-        dgraph.add_edges(source_vertices, target_vertices,
-                         timestamps, add_reverse=False)
-        self.assertEqual(dgraph.num_edges(), 18)
-        self.assertEqual(dgraph.num_vertices(), 4)
-        self.assertEqual(dgraph.out_degree(
-            [0, 1, 2, 3]).tolist(), [6, 6, 6, 0])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            0)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [11, 10, 9, 2, 1, 0])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            1)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [14, 13, 12, 5, 4, 3])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            2)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [17, 16, 15, 8, 7, 6])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            3)
-        self.assertEqual(target_vertices.tolist(), [])
-        self.assertEqual(timestamps.tolist(), [])
-        self.assertEqual(edge_ids.tolist(), [])
-        print("Test add edges multiple times passed. (replace policy) (mem_resource_type: {})".format(
-            mem_resource_type))
-
-    @unittest.skip("Not implemented yet")
-    def test_add_old_edges(self):
-        """
-        Test if raise an exception when adding edges with timestmaps that are
-        smaller than the current timestamps.
-        """
-        config = default_config.copy()
-        dgraph = DynamicGraph(**config)
-        source_vertices = np.array([0, 1, 2])
-        target_vertices = np.array([1, 2, 3])
-        timestamps = np.array([0, 1, 2])
-        dgraph.add_edges(source_vertices, target_vertices,
-                         timestamps, add_reverse=False)
-
-        source_vertices = np.array([0])
-        target_vertices = np.array([1])
-        timestamps = np.array([0])
-        with self.assertRaises(ValueError):
-            dgraph.add_edges(source_vertices, target_vertices, timestamps)
-
-        print("Test add old edges passed.")
-
-    @parameterized.expand(
-        itertools.product(["cuda", "unified", "pinned", "shared"]))
-    def test_insertion_policy_replace(self, mem_resource_type):
-        """
-        Test if the "replace" insertion policy works.
-        """
-        config = default_config.copy()
-        config["minimum_block_size"] = 4
-        config["insertion_policy"] = "replace"
-        config["mem_resource_type"] = mem_resource_type
-        dgraph = DynamicGraph(**config)
-        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
-        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
-        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
-        dgraph.add_edges(source_vertices, target_vertices,
-                         timestamps, add_reverse=False)
-
-        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
-        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
-        timestamps = np.array([3, 4, 5, 3, 4, 5, 3, 4, 5])
-        dgraph.add_edges(source_vertices, target_vertices,
-                         timestamps, add_reverse=False)
-
-        self.assertEqual(dgraph.num_edges(), 18)
-        self.assertEqual(dgraph.num_vertices(), 4)
-        self.assertEqual(dgraph.out_degree(
-            [0, 1, 2, 3]).tolist(), [6, 6, 6, 0])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            0)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [11, 10, 9, 2, 1, 0])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            1)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [14, 13, 12, 5, 4, 3])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            2)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [17, 16, 15, 8, 7, 6])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            3)
-        self.assertEqual(target_vertices.tolist(), [])
-        self.assertEqual(timestamps.tolist(), [])
-        self.assertEqual(edge_ids.tolist(), [])
-
-        print("Test replace insertion policy passed. (mem_resource_type: {})".format(
-            mem_resource_type))
-
-    @parameterized.expand(
-        itertools.product(["cuda", "unified", "pinned", "shared"]))
-    def test_add_edges_with_eids(self, mem_resource_type):
-        """
-        Test if the "replace" insertion policy works.
-        """
-        config = default_config.copy()
-        config["minimum_block_size"] = 4
-        config["mem_resource_type"] = mem_resource_type
-        dgraph = DynamicGraph(**config)
-        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
-        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
-        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
-        edge_ids = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8])
-        dgraph.add_edges(source_vertices, target_vertices,
-                         timestamps, edge_ids, add_reverse=False)
-
-        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
-        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
-        timestamps = np.array([3, 4, 5, 3, 4, 5, 3, 4, 5])
-        edge_ids = np.array([9, 10, 11, 12, 13, 14, 15, 16, 17])
-        dgraph.add_edges(source_vertices, target_vertices,
-                         timestamps, edge_ids, add_reverse=False)
-
-        self.assertEqual(dgraph.num_edges(), 18)
-        self.assertEqual(dgraph.num_vertices(), 4)
-        self.assertEqual(dgraph.out_degree(
-            [0, 1, 2, 3]).tolist(), [6, 6, 6, 0])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            0)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [11, 10, 9, 2, 1, 0])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            1)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [14, 13, 12, 5, 4, 3])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            2)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [17, 16, 15, 8, 7, 6])
-
-        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-            3)
-        self.assertEqual(target_vertices.tolist(), [])
-        self.assertEqual(timestamps.tolist(), [])
-        self.assertEqual(edge_ids.tolist(), [])
-
-        print("Test add edges with eids passed. (mem_resource_type: {})".format(
-            mem_resource_type))
-
-    @parameterized.expand(
-        itertools.product(["cuda", "unified", "pinned", "shared"]))
-    def test_add_edges_with_noncontinous_eids(self, mem_resource_type):
-        """
-        Test if the "replace" insertion policy works.
+        Test if the "offload_old_blocks(timestamp: float)" works
         """
         config = default_config.copy()
         config["minimum_block_size"] = 4
@@ -487,28 +538,29 @@ class TestDynamicGraph(unittest.TestCase):
         dgraph.add_edges(source_vertices, target_vertices,
                          timestamps, edge_ids, add_reverse=False)
 
-        self.assertEqual(dgraph.num_edges(), 18)
+        num_blocks = dgraph.offload_old_blocks(3.5, to_file)  # the first block is offloaded
+        print("offloaded {} blocks".format(num_blocks))
+
+        self.assertEqual(dgraph.num_edges(), 6)
         self.assertEqual(dgraph.num_vertices(), 4)
-        self.assertEqual(dgraph.out_degree(
-            [0, 1, 2, 3]).tolist(), [6, 6, 6, 0])
 
         target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
             0)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [21, 19, 17, 4, 2, 0])
+        self.assertEqual(target_vertices.tolist(), [3, 2])
+        self.assertEqual(timestamps.tolist(), [5, 4])
+        self.assertEqual(edge_ids.tolist(), [21, 19])
 
         target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
             1)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [27, 25, 23, 10, 8, 6])
+        self.assertEqual(target_vertices.tolist(), [3, 2])
+        self.assertEqual(timestamps.tolist(), [5, 4])
+        self.assertEqual(edge_ids.tolist(), [27, 25])
 
         target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
             2)
-        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-        self.assertEqual(edge_ids.tolist(), [33, 31, 29, 16, 14, 12])
+        self.assertEqual(target_vertices.tolist(), [3, 2])
+        self.assertEqual(timestamps.tolist(), [5, 4])
+        self.assertEqual(edge_ids.tolist(), [33, 31])
 
         target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
             3)
@@ -516,7 +568,7 @@ class TestDynamicGraph(unittest.TestCase):
         self.assertEqual(timestamps.tolist(), [])
         self.assertEqual(edge_ids.tolist(), [])
 
-        print("Test add edges with non-continous eids passed. (mem_resource_type: {})".format(
+        print("Test offload old blocks passed. (mem_resource_type: {})".format(
             mem_resource_type))
 
 

--- a/tests/test_dynamic_graph.py
+++ b/tests/test_dynamic_graph.py
@@ -21,498 +21,498 @@ default_config = {
 
 class TestDynamicGraph(unittest.TestCase):
 
-    #    @parameterized.expand(
-    #        itertools.product(["cuda", "unified", "pinned", "shared"]))
-    #    def test_add_edges_sorted_by_timestamp(self, mem_resource_type):
-    #        """
-    #        Test that adding edges sorted by timestamps works.
-    #        """
-    #        config = default_config.copy()
-    #        config["mem_resource_type"] = mem_resource_type
-    #        dgraph = DynamicGraph(**config)
-    #
-    #        source_vertices = np.array(
-    #            [0, 0, 0, 1, 1, 1, 2, 2, 2])
-    #        target_vertices = np.array(
-    #            [1, 2, 3, 1, 2, 3, 1, 2, 3])
-    #        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
-    #        dgraph.add_edges(source_vertices, target_vertices,
-    #                         timestamps, add_reverse=False)
-    #        self.assertEqual(dgraph.num_edges(), 9)
-    #        self.assertEqual(dgraph.num_vertices(), 4)
-    #        self.assertEqual(dgraph.out_degree(
-    #            [0, 1, 2, 3]).tolist(), [3, 3, 3, 0])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            0)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [2, 1, 0])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            1)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [5, 4, 3])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            2)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [8, 7, 6])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            3)
-    #        self.assertEqual(target_vertices.tolist(), [])
-    #        self.assertEqual(timestamps.tolist(), [])
-    #        self.assertEqual(edge_ids.tolist(), [])
-    #        print("Test add edges sorted by timestamps passed. (mem_resource_type: {})".format(
-    #            mem_resource_type))
-    #
-    #    @ parameterized.expand(
-    #        itertools.product(["cuda", "unified", "pinned", "shared"]))
-    #    def test_add_edges_sorted_by_timestamps_add_reverse(
-    #            self, mem_resource_type):
-    #        """
-    #        Test that adding edges sorted by timestamps works.
-    #        """
-    #        config = default_config.copy()
-    #        config["mem_resource_type"] = mem_resource_type
-    #        dgraph = DynamicGraph(**config)
-    #        source_vertices = np.array(
-    #            [0, 0, 0, 1, 1, 1, 2, 2, 2])
-    #        target_vertices = np.array(
-    #            [1, 2, 3, 1, 2, 3, 1, 2, 3])
-    #        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
-    #        dgraph.add_edges(source_vertices, target_vertices,
-    #                         timestamps, add_reverse=True)
-    #        self.assertEqual(dgraph.num_edges(), 9)
-    #        self.assertEqual(dgraph.num_vertices(), 4)
-    #        self.assertEqual(dgraph.out_degree(
-    #            [0, 1, 2, 3]).tolist(), [3, 6, 6, 3])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            0)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [2, 1, 0])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            1)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 2, 1, 0, 1])
-    #        self.assertEqual(timestamps.tolist(), [2, 1, 0, 0, 0, 0])
-    #        self.assertEqual(edge_ids.tolist(), [5, 4, 6, 3, 0, 3])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            2)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 0, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [2, 1, 1, 1, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [8, 7, 4, 1, 7, 6])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            3)
-    #        self.assertEqual(target_vertices.tolist(), [2, 1, 0])
-    #        self.assertEqual(timestamps.tolist(), [2, 2, 2])
-    #        self.assertEqual(edge_ids.tolist(), [8, 5, 2])
-    #        print("Test add edges sorted by timestamps passed (add reverse) (mem_resource_type: {})".format(
-    #            mem_resource_type))
-    #
-    #    @ parameterized.expand(
-    #        itertools.product(["cuda", "unified", "pinned", "shared"]))
-    #    def test_add_edges_unsorted(self, mem_resource_type):
-    #        """
-    #        Test that adding edges unsorted works.
-    #        """
-    #        config = default_config.copy()
-    #        config["mem_resource_type"] = mem_resource_type
-    #        dgraph = DynamicGraph(**config)
-    #        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
-    #        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
-    #        timestamps = np.array([2, 1, 0, 2, 1, 0, 2, 1, 0])
-    #        dgraph.add_edges(source_vertices, target_vertices,
-    #                         timestamps, add_reverse=False)
-    #        self.assertEqual(dgraph.num_edges(), 9)
-    #        self.assertEqual(dgraph.num_vertices(), 4)
-    #        self.assertEqual(dgraph.out_degree(
-    #            [0, 1, 2, 3]).tolist(), [3, 3, 3, 0])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            0)
-    #        self.assertEqual(target_vertices.tolist(), [1, 2, 3])
-    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [0, 1, 2])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            1)
-    #        self.assertEqual(target_vertices.tolist(), [1, 2, 3])
-    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [3, 4, 5])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            2)
-    #        self.assertEqual(target_vertices.tolist(), [1, 2, 3])
-    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [6, 7, 8])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            3)
-    #        self.assertEqual(target_vertices.tolist(), [])
-    #        self.assertEqual(timestamps.tolist(), [])
-    #        self.assertEqual(edge_ids.tolist(), [])
-    #        print("Test add edges unsorted passed (mem_resource_type: {})".format(
-    #            mem_resource_type))
-    #
-    #    @ parameterized.expand(
-    #        itertools.product(["cuda", "unified", "pinned", "shared"]))
-    #    def test_add_edges_multiple_times_insert(self, mem_resource_type):
-    #        """
-    #        Test that adding edges multiple times works.
-    #        """
-    #        config = default_config.copy()
-    #        config["minimum_block_size"] = 4
-    #        config["mem_resource_type"] = mem_resource_type
-    #        dgraph = DynamicGraph(**config)
-    #        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
-    #        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
-    #        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
-    #        dgraph.add_edges(source_vertices, target_vertices,
-    #                         timestamps, add_reverse=False)
-    #        self.assertEqual(dgraph.num_edges(), 9)
-    #        self.assertEqual(dgraph.num_vertices(), 4)
-    #        self.assertEqual(dgraph.out_degree(
-    #            [0, 1, 2, 3]).tolist(), [3, 3, 3, 0])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            0)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [2, 1, 0])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            1)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [5, 4, 3])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            2)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [8, 7, 6])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            3)
-    #        self.assertEqual(target_vertices.tolist(), [])
-    #        self.assertEqual(timestamps.tolist(), [])
-    #        self.assertEqual(edge_ids.tolist(), [])
-    #
-    #        # edges with newer timestamps should be added
-    #        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
-    #        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
-    #        timestamps = np.array([3, 4, 5, 3, 4, 5, 3, 4, 5])
-    #        dgraph.add_edges(source_vertices, target_vertices,
-    #                         timestamps, add_reverse=False)
-    #        self.assertEqual(dgraph.num_edges(), 18)
-    #        self.assertEqual(dgraph.num_vertices(), 4)
-    #        self.assertEqual(dgraph.out_degree(
-    #            [0, 1, 2, 3]).tolist(), [6, 6, 6, 0])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            0)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [11, 10, 9, 2, 1, 0])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            1)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [14, 13, 12, 5, 4, 3])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            2)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [17, 16, 15, 8, 7, 6])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            3)
-    #        self.assertEqual(target_vertices.tolist(), [])
-    #        self.assertEqual(timestamps.tolist(), [])
-    #        self.assertEqual(edge_ids.tolist(), [])
-    #        print("Test add edges multiple times passed. (insert policy) (mem_resource_type: {})".format(
-    #            mem_resource_type))
-    #
-    #    @ parameterized.expand(
-    #        itertools.product(["cuda", "unified", "pinned", "shared"]))
-    #    def test_add_edges_multiple_times_replace(self, mem_resource_type):
-    #        """
-    #        Test that adding edges multiple times works.
-    #        """
-    #        config = default_config.copy()
-    #        config["minimum_block_size"] = 4
-    #        config["insertion_policy"] = "replace"
-    #        config["mem_resource_type"] = mem_resource_type
-    #        dgraph = DynamicGraph(**config)
-    #        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
-    #        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
-    #        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
-    #        dgraph.add_edges(source_vertices, target_vertices,
-    #                         timestamps, add_reverse=False)
-    #        self.assertEqual(dgraph.num_edges(), 9)
-    #        self.assertEqual(dgraph.num_vertices(), 4)
-    #        self.assertEqual(dgraph.out_degree(
-    #            [0, 1, 2, 3]).tolist(), [3, 3, 3, 0])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            0)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [2, 1, 0])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            1)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [5, 4, 3])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            2)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [8, 7, 6])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            3)
-    #        self.assertEqual(target_vertices.tolist(), [])
-    #        self.assertEqual(timestamps.tolist(), [])
-    #        self.assertEqual(edge_ids.tolist(), [])
-    #
-    #        # edges with newer timestamps should be added
-    #        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
-    #        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
-    #        timestamps = np.array([3, 4, 5, 3, 4, 5, 3, 4, 5])
-    #        dgraph.add_edges(source_vertices, target_vertices,
-    #                         timestamps, add_reverse=False)
-    #        self.assertEqual(dgraph.num_edges(), 18)
-    #        self.assertEqual(dgraph.num_vertices(), 4)
-    #        self.assertEqual(dgraph.out_degree(
-    #            [0, 1, 2, 3]).tolist(), [6, 6, 6, 0])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            0)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [11, 10, 9, 2, 1, 0])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            1)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [14, 13, 12, 5, 4, 3])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            2)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [17, 16, 15, 8, 7, 6])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            3)
-    #        self.assertEqual(target_vertices.tolist(), [])
-    #        self.assertEqual(timestamps.tolist(), [])
-    #        self.assertEqual(edge_ids.tolist(), [])
-    #        print("Test add edges multiple times passed. (replace policy) (mem_resource_type: {})".format(
-    #            mem_resource_type))
-    #
-    #    @unittest.skip("Not implemented yet")
-    #    def test_add_old_edges(self):
-    #        """
-    #        Test if raise an exception when adding edges with timestmaps that are
-    #        smaller than the current timestamps.
-    #        """
-    #        config = default_config.copy()
-    #        dgraph = DynamicGraph(**config)
-    #        source_vertices = np.array([0, 1, 2])
-    #        target_vertices = np.array([1, 2, 3])
-    #        timestamps = np.array([0, 1, 2])
-    #        dgraph.add_edges(source_vertices, target_vertices,
-    #                         timestamps, add_reverse=False)
-    #
-    #        source_vertices = np.array([0])
-    #        target_vertices = np.array([1])
-    #        timestamps = np.array([0])
-    #        with self.assertRaises(ValueError):
-    #            dgraph.add_edges(source_vertices, target_vertices, timestamps)
-    #
-    #        print("Test add old edges passed.")
-    #
-    #    @parameterized.expand(
-    #        itertools.product(["cuda", "unified", "pinned", "shared"]))
-    #    def test_insertion_policy_replace(self, mem_resource_type):
-    #        """
-    #        Test if the "replace" insertion policy works.
-    #        """
-    #        config = default_config.copy()
-    #        config["minimum_block_size"] = 4
-    #        config["insertion_policy"] = "replace"
-    #        config["mem_resource_type"] = mem_resource_type
-    #        dgraph = DynamicGraph(**config)
-    #        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
-    #        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
-    #        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
-    #        dgraph.add_edges(source_vertices, target_vertices,
-    #                         timestamps, add_reverse=False)
-    #
-    #        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
-    #        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
-    #        timestamps = np.array([3, 4, 5, 3, 4, 5, 3, 4, 5])
-    #        dgraph.add_edges(source_vertices, target_vertices,
-    #                         timestamps, add_reverse=False)
-    #
-    #        self.assertEqual(dgraph.num_edges(), 18)
-    #        self.assertEqual(dgraph.num_vertices(), 4)
-    #        self.assertEqual(dgraph.out_degree(
-    #            [0, 1, 2, 3]).tolist(), [6, 6, 6, 0])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            0)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [11, 10, 9, 2, 1, 0])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            1)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [14, 13, 12, 5, 4, 3])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            2)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [17, 16, 15, 8, 7, 6])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            3)
-    #        self.assertEqual(target_vertices.tolist(), [])
-    #        self.assertEqual(timestamps.tolist(), [])
-    #        self.assertEqual(edge_ids.tolist(), [])
-    #
-    #        print("Test replace insertion policy passed. (mem_resource_type: {})".format(
-    #            mem_resource_type))
-    #
-    #    @parameterized.expand(
-    #        itertools.product(["cuda", "unified", "pinned", "shared"]))
-    #    def test_add_edges_with_eids(self, mem_resource_type):
-    #        """
-    #        Test if the "replace" insertion policy works.
-    #        """
-    #        config = default_config.copy()
-    #        config["minimum_block_size"] = 4
-    #        config["mem_resource_type"] = mem_resource_type
-    #        dgraph = DynamicGraph(**config)
-    #        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
-    #        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
-    #        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
-    #        edge_ids = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8])
-    #        dgraph.add_edges(source_vertices, target_vertices,
-    #                         timestamps, edge_ids, add_reverse=False)
-    #
-    #        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
-    #        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
-    #        timestamps = np.array([3, 4, 5, 3, 4, 5, 3, 4, 5])
-    #        edge_ids = np.array([9, 10, 11, 12, 13, 14, 15, 16, 17])
-    #        dgraph.add_edges(source_vertices, target_vertices,
-    #                         timestamps, edge_ids, add_reverse=False)
-    #
-    #        self.assertEqual(dgraph.num_edges(), 18)
-    #        self.assertEqual(dgraph.num_vertices(), 4)
-    #        self.assertEqual(dgraph.out_degree(
-    #            [0, 1, 2, 3]).tolist(), [6, 6, 6, 0])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            0)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [11, 10, 9, 2, 1, 0])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            1)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [14, 13, 12, 5, 4, 3])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            2)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [17, 16, 15, 8, 7, 6])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            3)
-    #        self.assertEqual(target_vertices.tolist(), [])
-    #        self.assertEqual(timestamps.tolist(), [])
-    #        self.assertEqual(edge_ids.tolist(), [])
-    #
-    #        print("Test add edges with eids passed. (mem_resource_type: {})".format(
-    #            mem_resource_type))
-    #
-    #    @parameterized.expand(
-    #        itertools.product(["cuda", "unified", "pinned", "shared"]))
-    #    def test_add_edges_with_noncontinous_eids(self, mem_resource_type):
-    #        """
-    #        Test if the "replace" insertion policy works.
-    #        """
-    #        config = default_config.copy()
-    #        config["minimum_block_size"] = 4
-    #        config["mem_resource_type"] = mem_resource_type
-    #        dgraph = DynamicGraph(**config)
-    #        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
-    #        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
-    #        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
-    #        edge_ids = np.array([0, 2, 4, 6, 8, 10, 12, 14, 16])
-    #        dgraph.add_edges(source_vertices, target_vertices,
-    #                         timestamps, edge_ids, add_reverse=False)
-    #
-    #        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
-    #        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
-    #        timestamps = np.array([3, 4, 5, 3, 4, 5, 3, 4, 5])
-    #        edge_ids = np.array([17, 19, 21, 23, 25, 27, 29, 31, 33])
-    #        dgraph.add_edges(source_vertices, target_vertices,
-    #                         timestamps, edge_ids, add_reverse=False)
-    #
-    #        self.assertEqual(dgraph.num_edges(), 18)
-    #        self.assertEqual(dgraph.num_vertices(), 4)
-    #        self.assertEqual(dgraph.out_degree(
-    #            [0, 1, 2, 3]).tolist(), [6, 6, 6, 0])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            0)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [21, 19, 17, 4, 2, 0])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            1)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [27, 25, 23, 10, 8, 6])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            2)
-    #        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
-    #        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
-    #        self.assertEqual(edge_ids.tolist(), [33, 31, 29, 16, 14, 12])
-    #
-    #        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
-    #            3)
-    #        self.assertEqual(target_vertices.tolist(), [])
-    #        self.assertEqual(timestamps.tolist(), [])
-    #        self.assertEqual(edge_ids.tolist(), [])
-    #
-    #        print("Test add edges with non-continous eids passed. (mem_resource_type: {})".format(
-    #            mem_resource_type))
+    @parameterized.expand(
+        itertools.product(["cuda", "unified", "pinned", "shared"]))
+    def test_add_edges_sorted_by_timestamp(self, mem_resource_type):
+        """
+        Test that adding edges sorted by timestamps works.
+        """
+        config = default_config.copy()
+        config["mem_resource_type"] = mem_resource_type
+        dgraph = DynamicGraph(**config)
+
+        source_vertices = np.array(
+            [0, 0, 0, 1, 1, 1, 2, 2, 2])
+        target_vertices = np.array(
+            [1, 2, 3, 1, 2, 3, 1, 2, 3])
+        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
+        dgraph.add_edges(source_vertices, target_vertices,
+                         timestamps, add_reverse=False)
+        self.assertEqual(dgraph.num_edges(), 9)
+        self.assertEqual(dgraph.num_vertices(), 4)
+        self.assertEqual(dgraph.out_degree(
+            [0, 1, 2, 3]).tolist(), [3, 3, 3, 0])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            0)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [2, 1, 0])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            1)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [5, 4, 3])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            2)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [8, 7, 6])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            3)
+        self.assertEqual(target_vertices.tolist(), [])
+        self.assertEqual(timestamps.tolist(), [])
+        self.assertEqual(edge_ids.tolist(), [])
+        print("Test add edges sorted by timestamps passed. (mem_resource_type: {})".format(
+            mem_resource_type))
+
+    @ parameterized.expand(
+        itertools.product(["cuda", "unified", "pinned", "shared"]))
+    def test_add_edges_sorted_by_timestamps_add_reverse(
+            self, mem_resource_type):
+        """
+        Test that adding edges sorted by timestamps works.
+        """
+        config = default_config.copy()
+        config["mem_resource_type"] = mem_resource_type
+        dgraph = DynamicGraph(**config)
+        source_vertices = np.array(
+            [0, 0, 0, 1, 1, 1, 2, 2, 2])
+        target_vertices = np.array(
+            [1, 2, 3, 1, 2, 3, 1, 2, 3])
+        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
+        dgraph.add_edges(source_vertices, target_vertices,
+                         timestamps, add_reverse=True)
+        self.assertEqual(dgraph.num_edges(), 9)
+        self.assertEqual(dgraph.num_vertices(), 4)
+        self.assertEqual(dgraph.out_degree(
+            [0, 1, 2, 3]).tolist(), [3, 6, 6, 3])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            0)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [2, 1, 0])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            1)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 2, 1, 0, 1])
+        self.assertEqual(timestamps.tolist(), [2, 1, 0, 0, 0, 0])
+        self.assertEqual(edge_ids.tolist(), [5, 4, 6, 3, 0, 3])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            2)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 0, 2, 1])
+        self.assertEqual(timestamps.tolist(), [2, 1, 1, 1, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [8, 7, 4, 1, 7, 6])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            3)
+        self.assertEqual(target_vertices.tolist(), [2, 1, 0])
+        self.assertEqual(timestamps.tolist(), [2, 2, 2])
+        self.assertEqual(edge_ids.tolist(), [8, 5, 2])
+        print("Test add edges sorted by timestamps passed (add reverse) (mem_resource_type: {})".format(
+            mem_resource_type))
+
+    @ parameterized.expand(
+        itertools.product(["cuda", "unified", "pinned", "shared"]))
+    def test_add_edges_unsorted(self, mem_resource_type):
+        """
+        Test that adding edges unsorted works.
+        """
+        config = default_config.copy()
+        config["mem_resource_type"] = mem_resource_type
+        dgraph = DynamicGraph(**config)
+        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+        timestamps = np.array([2, 1, 0, 2, 1, 0, 2, 1, 0])
+        dgraph.add_edges(source_vertices, target_vertices,
+                         timestamps, add_reverse=False)
+        self.assertEqual(dgraph.num_edges(), 9)
+        self.assertEqual(dgraph.num_vertices(), 4)
+        self.assertEqual(dgraph.out_degree(
+            [0, 1, 2, 3]).tolist(), [3, 3, 3, 0])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            0)
+        self.assertEqual(target_vertices.tolist(), [1, 2, 3])
+        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [0, 1, 2])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            1)
+        self.assertEqual(target_vertices.tolist(), [1, 2, 3])
+        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [3, 4, 5])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            2)
+        self.assertEqual(target_vertices.tolist(), [1, 2, 3])
+        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [6, 7, 8])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            3)
+        self.assertEqual(target_vertices.tolist(), [])
+        self.assertEqual(timestamps.tolist(), [])
+        self.assertEqual(edge_ids.tolist(), [])
+        print("Test add edges unsorted passed (mem_resource_type: {})".format(
+            mem_resource_type))
+
+    @ parameterized.expand(
+        itertools.product(["cuda", "unified", "pinned", "shared"]))
+    def test_add_edges_multiple_times_insert(self, mem_resource_type):
+        """
+        Test that adding edges multiple times works.
+        """
+        config = default_config.copy()
+        config["minimum_block_size"] = 4
+        config["mem_resource_type"] = mem_resource_type
+        dgraph = DynamicGraph(**config)
+        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
+        dgraph.add_edges(source_vertices, target_vertices,
+                         timestamps, add_reverse=False)
+        self.assertEqual(dgraph.num_edges(), 9)
+        self.assertEqual(dgraph.num_vertices(), 4)
+        self.assertEqual(dgraph.out_degree(
+            [0, 1, 2, 3]).tolist(), [3, 3, 3, 0])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            0)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [2, 1, 0])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            1)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [5, 4, 3])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            2)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [8, 7, 6])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            3)
+        self.assertEqual(target_vertices.tolist(), [])
+        self.assertEqual(timestamps.tolist(), [])
+        self.assertEqual(edge_ids.tolist(), [])
+
+        # edges with newer timestamps should be added
+        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+        timestamps = np.array([3, 4, 5, 3, 4, 5, 3, 4, 5])
+        dgraph.add_edges(source_vertices, target_vertices,
+                         timestamps, add_reverse=False)
+        self.assertEqual(dgraph.num_edges(), 18)
+        self.assertEqual(dgraph.num_vertices(), 4)
+        self.assertEqual(dgraph.out_degree(
+            [0, 1, 2, 3]).tolist(), [6, 6, 6, 0])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            0)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [11, 10, 9, 2, 1, 0])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            1)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [14, 13, 12, 5, 4, 3])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            2)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [17, 16, 15, 8, 7, 6])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            3)
+        self.assertEqual(target_vertices.tolist(), [])
+        self.assertEqual(timestamps.tolist(), [])
+        self.assertEqual(edge_ids.tolist(), [])
+        print("Test add edges multiple times passed. (insert policy) (mem_resource_type: {})".format(
+            mem_resource_type))
+
+    @ parameterized.expand(
+        itertools.product(["cuda", "unified", "pinned", "shared"]))
+    def test_add_edges_multiple_times_replace(self, mem_resource_type):
+        """
+        Test that adding edges multiple times works.
+        """
+        config = default_config.copy()
+        config["minimum_block_size"] = 4
+        config["insertion_policy"] = "replace"
+        config["mem_resource_type"] = mem_resource_type
+        dgraph = DynamicGraph(**config)
+        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
+        dgraph.add_edges(source_vertices, target_vertices,
+                         timestamps, add_reverse=False)
+        self.assertEqual(dgraph.num_edges(), 9)
+        self.assertEqual(dgraph.num_vertices(), 4)
+        self.assertEqual(dgraph.out_degree(
+            [0, 1, 2, 3]).tolist(), [3, 3, 3, 0])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            0)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [2, 1, 0])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            1)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [5, 4, 3])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            2)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [8, 7, 6])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            3)
+        self.assertEqual(target_vertices.tolist(), [])
+        self.assertEqual(timestamps.tolist(), [])
+        self.assertEqual(edge_ids.tolist(), [])
+
+        # edges with newer timestamps should be added
+        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+        timestamps = np.array([3, 4, 5, 3, 4, 5, 3, 4, 5])
+        dgraph.add_edges(source_vertices, target_vertices,
+                         timestamps, add_reverse=False)
+        self.assertEqual(dgraph.num_edges(), 18)
+        self.assertEqual(dgraph.num_vertices(), 4)
+        self.assertEqual(dgraph.out_degree(
+            [0, 1, 2, 3]).tolist(), [6, 6, 6, 0])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            0)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [11, 10, 9, 2, 1, 0])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            1)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [14, 13, 12, 5, 4, 3])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            2)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [17, 16, 15, 8, 7, 6])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            3)
+        self.assertEqual(target_vertices.tolist(), [])
+        self.assertEqual(timestamps.tolist(), [])
+        self.assertEqual(edge_ids.tolist(), [])
+        print("Test add edges multiple times passed. (replace policy) (mem_resource_type: {})".format(
+            mem_resource_type))
+
+    @unittest.skip("Not implemented yet")
+    def test_add_old_edges(self):
+        """
+        Test if raise an exception when adding edges with timestmaps that are
+        smaller than the current timestamps.
+        """
+        config = default_config.copy()
+        dgraph = DynamicGraph(**config)
+        source_vertices = np.array([0, 1, 2])
+        target_vertices = np.array([1, 2, 3])
+        timestamps = np.array([0, 1, 2])
+        dgraph.add_edges(source_vertices, target_vertices,
+                         timestamps, add_reverse=False)
+
+        source_vertices = np.array([0])
+        target_vertices = np.array([1])
+        timestamps = np.array([0])
+        with self.assertRaises(ValueError):
+            dgraph.add_edges(source_vertices, target_vertices, timestamps)
+
+        print("Test add old edges passed.")
+
+    @parameterized.expand(
+        itertools.product(["cuda", "unified", "pinned", "shared"]))
+    def test_insertion_policy_replace(self, mem_resource_type):
+        """
+        Test if the "replace" insertion policy works.
+        """
+        config = default_config.copy()
+        config["minimum_block_size"] = 4
+        config["insertion_policy"] = "replace"
+        config["mem_resource_type"] = mem_resource_type
+        dgraph = DynamicGraph(**config)
+        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
+        dgraph.add_edges(source_vertices, target_vertices,
+                         timestamps, add_reverse=False)
+
+        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+        timestamps = np.array([3, 4, 5, 3, 4, 5, 3, 4, 5])
+        dgraph.add_edges(source_vertices, target_vertices,
+                         timestamps, add_reverse=False)
+
+        self.assertEqual(dgraph.num_edges(), 18)
+        self.assertEqual(dgraph.num_vertices(), 4)
+        self.assertEqual(dgraph.out_degree(
+            [0, 1, 2, 3]).tolist(), [6, 6, 6, 0])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            0)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [11, 10, 9, 2, 1, 0])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            1)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [14, 13, 12, 5, 4, 3])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            2)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [17, 16, 15, 8, 7, 6])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            3)
+        self.assertEqual(target_vertices.tolist(), [])
+        self.assertEqual(timestamps.tolist(), [])
+        self.assertEqual(edge_ids.tolist(), [])
+
+        print("Test replace insertion policy passed. (mem_resource_type: {})".format(
+            mem_resource_type))
+
+    @parameterized.expand(
+        itertools.product(["cuda", "unified", "pinned", "shared"]))
+    def test_add_edges_with_eids(self, mem_resource_type):
+        """
+        Test if the "replace" insertion policy works.
+        """
+        config = default_config.copy()
+        config["minimum_block_size"] = 4
+        config["mem_resource_type"] = mem_resource_type
+        dgraph = DynamicGraph(**config)
+        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
+        edge_ids = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8])
+        dgraph.add_edges(source_vertices, target_vertices,
+                         timestamps, edge_ids, add_reverse=False)
+
+        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+        timestamps = np.array([3, 4, 5, 3, 4, 5, 3, 4, 5])
+        edge_ids = np.array([9, 10, 11, 12, 13, 14, 15, 16, 17])
+        dgraph.add_edges(source_vertices, target_vertices,
+                         timestamps, edge_ids, add_reverse=False)
+
+        self.assertEqual(dgraph.num_edges(), 18)
+        self.assertEqual(dgraph.num_vertices(), 4)
+        self.assertEqual(dgraph.out_degree(
+            [0, 1, 2, 3]).tolist(), [6, 6, 6, 0])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            0)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [11, 10, 9, 2, 1, 0])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            1)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [14, 13, 12, 5, 4, 3])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            2)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [17, 16, 15, 8, 7, 6])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            3)
+        self.assertEqual(target_vertices.tolist(), [])
+        self.assertEqual(timestamps.tolist(), [])
+        self.assertEqual(edge_ids.tolist(), [])
+
+        print("Test add edges with eids passed. (mem_resource_type: {})".format(
+            mem_resource_type))
+
+    @parameterized.expand(
+        itertools.product(["cuda", "unified", "pinned", "shared"]))
+    def test_add_edges_with_noncontinous_eids(self, mem_resource_type):
+        """
+        Test if the "replace" insertion policy works.
+        """
+        config = default_config.copy()
+        config["minimum_block_size"] = 4
+        config["mem_resource_type"] = mem_resource_type
+        dgraph = DynamicGraph(**config)
+        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+        timestamps = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
+        edge_ids = np.array([0, 2, 4, 6, 8, 10, 12, 14, 16])
+        dgraph.add_edges(source_vertices, target_vertices,
+                         timestamps, edge_ids, add_reverse=False)
+
+        source_vertices = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+        target_vertices = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+        timestamps = np.array([3, 4, 5, 3, 4, 5, 3, 4, 5])
+        edge_ids = np.array([17, 19, 21, 23, 25, 27, 29, 31, 33])
+        dgraph.add_edges(source_vertices, target_vertices,
+                         timestamps, edge_ids, add_reverse=False)
+
+        self.assertEqual(dgraph.num_edges(), 18)
+        self.assertEqual(dgraph.num_vertices(), 4)
+        self.assertEqual(dgraph.out_degree(
+            [0, 1, 2, 3]).tolist(), [6, 6, 6, 0])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            0)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [21, 19, 17, 4, 2, 0])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            1)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [27, 25, 23, 10, 8, 6])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            2)
+        self.assertEqual(target_vertices.tolist(), [3, 2, 1, 3, 2, 1])
+        self.assertEqual(timestamps.tolist(), [5, 4, 3, 2, 1, 0])
+        self.assertEqual(edge_ids.tolist(), [33, 31, 29, 16, 14, 12])
+
+        target_vertices, timestamps, edge_ids = dgraph.get_temporal_neighbors(
+            3)
+        self.assertEqual(target_vertices.tolist(), [])
+        self.assertEqual(timestamps.tolist(), [])
+        self.assertEqual(edge_ids.tolist(), [])
+
+        print("Test add edges with non-continous eids passed. (mem_resource_type: {})".format(
+            mem_resource_type))
 
     @parameterized.expand(
         itertools.product(["pinned"], [True, False]))
@@ -538,7 +538,8 @@ class TestDynamicGraph(unittest.TestCase):
         dgraph.add_edges(source_vertices, target_vertices,
                          timestamps, edge_ids, add_reverse=False)
 
-        num_blocks = dgraph.offload_old_blocks(3.5, to_file)  # the first block is offloaded
+        num_blocks = dgraph.offload_old_blocks(
+            3.5, to_file)  # the first block is offloaded
         print("offloaded {} blocks".format(num_blocks))
 
         self.assertEqual(dgraph.num_edges(), 6)

--- a/tests/test_dynamic_graph.py
+++ b/tests/test_dynamic_graph.py
@@ -69,7 +69,7 @@ class TestDynamicGraph(unittest.TestCase):
         print("Test add edges sorted by timestamps passed. (mem_resource_type: {})".format(
             mem_resource_type))
 
-    @ parameterized.expand(
+    @parameterized.expand(
         itertools.product(["cuda", "unified", "pinned", "shared"]))
     def test_add_edges_sorted_by_timestamps_add_reverse(
             self, mem_resource_type):
@@ -117,7 +117,7 @@ class TestDynamicGraph(unittest.TestCase):
         print("Test add edges sorted by timestamps passed (add reverse) (mem_resource_type: {})".format(
             mem_resource_type))
 
-    @ parameterized.expand(
+    @parameterized.expand(
         itertools.product(["cuda", "unified", "pinned", "shared"]))
     def test_add_edges_unsorted(self, mem_resource_type):
         """
@@ -162,7 +162,7 @@ class TestDynamicGraph(unittest.TestCase):
         print("Test add edges unsorted passed (mem_resource_type: {})".format(
             mem_resource_type))
 
-    @ parameterized.expand(
+    @parameterized.expand(
         itertools.product(["cuda", "unified", "pinned", "shared"]))
     def test_add_edges_multiple_times_insert(self, mem_resource_type):
         """
@@ -243,7 +243,7 @@ class TestDynamicGraph(unittest.TestCase):
         print("Test add edges multiple times passed. (insert policy) (mem_resource_type: {})".format(
             mem_resource_type))
 
-    @ parameterized.expand(
+    @parameterized.expand(
         itertools.product(["cuda", "unified", "pinned", "shared"]))
     def test_add_edges_multiple_times_replace(self, mem_resource_type):
         """

--- a/tests/test_temporal_sampler.py
+++ b/tests/test_temporal_sampler.py
@@ -237,7 +237,7 @@ class TestTemporalSampler(unittest.TestCase):
             0, 1, 2])
         print("Test sample_layer with multiple blocks (offload) passed")
 
-    @ parameterized.expand(
+    @parameterized.expand(
         itertools.product(["cuda", "unified", "pinned", "shared"]))
     def test_sampler_layer_with_duplicate_vertices(self, mem_resource_type):
         # build the dynamic graph
@@ -292,7 +292,7 @@ class TestTemporalSampler(unittest.TestCase):
 
         print("Test sampler_layer_with_duplicate_vertices passed")
 
-    @ parameterized.expand(
+    @parameterized.expand(
         itertools.product(["cuda", "unified", "pinned", "shared"]))
     def test_sample_multi_layers(self, mem_resource_type):
         # build the dynamic graph
@@ -385,7 +385,7 @@ class TestTemporalSampler(unittest.TestCase):
 
         print("Test sample_multi_layers passed")
 
-    @ parameterized.expand(
+    @parameterized.expand(
         itertools.product(["cuda", "unified", "pinned", "shared"]))
     def test_sample_multi_snapshots(self, mem_resource_type):
         # build the dynamic graph
@@ -488,7 +488,7 @@ class TestTemporalSampler(unittest.TestCase):
 
         print("Test sample_multi_snapshots passed")
 
-    @ parameterized.expand(
+    @parameterized.expand(
         itertools.product(["cuda", "unified", "pinned", "shared"]))
     def test_sample_multi_layers_multi_snapshots(self, mem_resource_type):
         # build the dynamic graph
@@ -655,7 +655,7 @@ class TestTemporalSampler(unittest.TestCase):
 
         print("Test sample_multi_layers_multi_snapshots passed")
 
-    @ parameterized.expand(
+    @parameterized.expand(
         itertools.product(["cuda", "unified", "pinned", "shared"]))
     def test_sample_layer_with_different_batch_size(self, mem_resource_type):
         # build the dynamic graph
@@ -681,7 +681,7 @@ class TestTemporalSampler(unittest.TestCase):
 
         print("Test sample_layer_with_different_batch_size passed")
 
-    @ unittest.skip("debug only")
+    @unittest.skip("debug only")
     def test_sampler_use_df(self):
         train_df, _, _, df = load_dataset(dataset="REDDIT")
         train_edge_end = df[df['ext_roll'].gt(0)].index[0]


### PR DESCRIPTION
Provide a new API called `offload_old_blocks` in `DynamicGraph`: 
```py
    def offload_old_blocks(self, timestamp: float, to_file: bool = False):
        """
        Offload the old blocks from the graph.
        Args:
            timestamp: the current timestamp.
            to_file: whether to offload the blocks to file.
        Return:
            the number of blocks offloaded.
        """
        return self._dgraph.offload_old_blocks(timestamp, to_file)
```

The intuition is that the importance of edges decay with time. So blocks are not needed when they become stale. 

Only support pinned memory and shared memory now. 