### PR TITLE
feat: pre-sampling

### DIFF
--- a/gnnflow/csrc/api.cc
+++ b/gnnflow/csrc/api.cc
@@ -46,7 +46,8 @@ PYBIND11_MODULE(libgnnflow, m) {
            py::arg("blocks_to_preallocate"), py::arg("insertion_policy"),
            py::arg("device"), py::arg("adaptive_block_size"))
       .def("add_edges", &DynamicGraph::AddEdges, py::arg("source_vertices"),
-           py::arg("target_vertices"), py::arg("timestamps"), py::arg("eids"))
+           py::arg("target_vertices"), py::arg("timestamps"), py::arg("eids"),
+           py::call_guard<py::gil_scoped_release>())
       .def("offload_old_blocks", &DynamicGraph::OffloadOldBlocks,
            py::arg("timestamp"), py::arg("to_file") = false)
       .def("num_vertices", &DynamicGraph::num_nodes)
@@ -113,8 +114,10 @@ PYBIND11_MODULE(libgnnflow, m) {
            py::arg("dgraph"), py::arg("fanouts"), py::arg("sampling_policy"),
            py::arg("num_snapshots"), py::arg("snapshot_time_window"),
            py::arg("prop_time"), py::arg("seed"))
-      .def("sample", &TemporalSampler::Sample)
-      .def("sample_layer", &TemporalSampler::SampleLayer);
+      .def("sample", &TemporalSampler::Sample,
+           py::call_guard<py::gil_scoped_release>())
+      .def("sample_layer", &TemporalSampler::SampleLayer,
+           py::call_guard<py::gil_scoped_release>());
 
   py::class_<KVStore>(m, "KVStore")
       .def(py::init<>())

--- a/scripts/offline_edge_prediction.py
+++ b/scripts/offline_edge_prediction.py
@@ -168,7 +168,11 @@ def main():
     logging.info("rank: {}, world_size: {}".format(args.rank, args.world_size))
 
     model_config, data_config = get_default_config(args.model, args.data)
-    model_config["snapshot_time_window"] = args.snapshot_time_window
+    if model_config["snapshot_time_window"] > 0 and args.data == "GDELT":
+        model_config["snapshot_time_window"] = 25
+    else:
+        model_config["snapshot_time_window"] = args.snapshot_time_window
+    logging.info("snapshot_time_window's value is {}".format(model_config["snapshot_time_window"]))
     args.use_memory = model_config['use_memory']
 
     if args.distributed:

--- a/scripts/offline_edge_prediction.py
+++ b/scripts/offline_edge_prediction.py
@@ -231,7 +231,8 @@ def main():
     dgraph = build_dynamic_graph(
         **data_config, device=args.local_rank)
 
-    torch.distributed.barrier()
+    if args.distributed:
+        torch.distributed.barrier()
     # insert in batch
     for i in tqdm(range(0, len(full_data), args.ingestion_batch_size)):
         batch = full_data[i:i + args.ingestion_batch_size]
@@ -241,7 +242,8 @@ def main():
         eids = batch["eid"].values.astype(np.int64)
         dgraph.add_edges(src_nodes, dst_nodes, timestamps,
                          eids, add_reverse=False)
-        torch.distributed.barrier()
+        if args.distributed:
+            torch.distributed.barrier()
 
     num_nodes = dgraph.max_vertex_id() + 1
     num_edges = dgraph.num_edges()

--- a/scripts/offline_edge_prediction.py
+++ b/scripts/offline_edge_prediction.py
@@ -337,6 +337,9 @@ def train(train_loader, val_loader, sampler, model, optimizer, criterion,
         gpu_load_thread.start()
 
     logging.info('Start training...')
+    if args.distributed:
+        torch.distributed.barrier()
+
     for e in range(args.epoch):
         model.train()
         cache.reset()

--- a/scripts/run_offline.sh
+++ b/scripts/run_offline.sh
@@ -24,4 +24,4 @@ else
 fi
 
 echo $cmd
-OMP_NUM_THREADS=8 exec $cmd > ${MODEL}_${DATA}_${CACHE}_${EDGE_CACHE_RATIO}_${NODE_CACHE_RATIO}_${TIME_WINDOW}.log 2>&1
+OMP_NUM_THREADS=8 exec $cmd > ${MODEL}_${DATA}_${CACHE}_${EDGE_CACHE_RATIO}_${NODE_CACHE_RATIO}_${TIME_WINDOW}_presampling.log 2>&1


### PR DESCRIPTION
This PR only covers the single-machine training script. Pre-sampling improves the training throughput on GDELT on 4xA100 GPUs by up to 1.47x. 

Here are the complete results along with time breakdowns. The default hyperparameters, such as batch size and fanouts, were used. The pre-sampling time was computed by subtracting the total time from the time taken by other stages.


| TGN's cumulative time  | w/o pre-sampling  | w/ pre-sampling | w/ pre-sampling w/ GIL release| 
| --- | --- | --- | --- |
| Sample (second) | 107.81 | 146.75 | 73.21  | 
| Feature Fetching (second) |40.05 | 51.15  | 93.90|
| Memory Fetching (second) | 55.89 | 74.18 | 64.94 | 
| Model Train (second) | 133.27 | 139.96| 140.34 | 
| Memory Update (second) |29.52 | 29.24 | 28.46 |
| Throughput (samples/s) | 978710.12  | 870026.74 | 957765.28 (0.98x) | 


| TGAT's cumulative time  | w/o pre-sampling  | w/ pre-sampling | w/ pre-sampling w/ GIL release| 
| --- | --- | --- | --- |
| Sample (second) | 1615.54 | 1789.69 | 601.47 | 
| Feature Fetching (second)|1233.05 | 1176.75 |  1255.53 |
| Model Train (second)|  1139.23 | 1149.03 |  1132.83| 
| Throughput (samples/s )| 94681.67 | 93595.10  | 128832.98 (1.36x) |


| DySAT's cumulative time  | w/o pre-sampling  | w/ pre-sampling w/ GIL release| 
| --- | --- | --- | 
| Sample (second) | 1931.05 | 716.06 | 
| Feature Fetching (second)|688.48 | 787.35 |  
| Model Train (second)|  1942.29 | 2430.12 |  
| Throughput (samples/s )| 82520.29 | 97924.22 (1.19x) | 


| GraphSAGE's cumulative time  | w/o pre-sampling  | w/ pre-sampling w/ GIL release| 
| --- | --- | --- | 
| Sample (second) | 1966.26 | 495.08 | 
| Feature Fetching (second)|1539.45 | 1837.84  | 
| Model Train (second)|  941.65 | 298.84 | 
| Throughput (samples/s )| 99470.85 | 146083.56 (1.47x) | 


| GAT's cumulative time  | w/o pre-sampling  | w/ pre-sampling w/ GIL release| 
| --- | --- | --- | 
| Sample (second) | 1565.81 | 568.68 | 
| Feature Fetching (second)|1219.04 | 1434.58  | 
| Model Train (second)|  1139.23 | 967.24 |  
| Throughput (samples/s )| 101284.63 | 129671.03 (1.28x) |